### PR TITLE
로깅, 문서화 의존성 추가 및 설정, BaseEntity 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,intellij,java,gradle
+src/main/resources/application-db.yml

--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,14 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.1'
+
 	compileOnly 'org.projectlombok:lombok'
-//	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/kr/ac/sejong/ds/palette/common/BaseEntity.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/BaseEntity.java
@@ -1,0 +1,25 @@
+package kr.ac.sejong.ds.palette.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/config/JpaAuditingConfiguration.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package kr.ac.sejong.ds.palette.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/config/SwaggerConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package kr.ac.sejong.ds.palette.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(title = "Palette API",
+                description = "커플 데이트 코스 추천 서비스 'Palette'의 API 문서입니다",
+                version = "v1"))
+@RequiredArgsConstructor
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi chatOpenApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("Palette API")
+                .pathsToMatch(paths)
+                .build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=palette

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  application:
+    name: palette
+  profiles:
+    include: db
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Property 영역 -->
+    <property name="LOG_PATH" value="./logs"/>
+
+    <!-- Appenders 영역 -->
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <!-- Encoder 영역 -->
+        <encoder>
+            <!-- Pattern 영역 -->
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%thread] %logger %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Appenders 영역 -->
+    <appender name="INFO_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <file>${LOG_PATH}/info.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/info_${type}.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <!-- Encoder 영역 -->
+        <encoder>
+            <!-- Pattern 영역 -->
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%thread] %logger %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- TRACE > DEBUG > INFO > WARN > ERROR > OFF -->
+    <!-- Root 영역 -->
+    <root level="INFO">
+        <appender-ref ref="console"/>
+        <appender-ref ref="INFO_LOG"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 📄 Description

- close : #4 

> 로깅과 문서화를 위한 의존성을 추가하고, BaseEntity를 생성함

## 📌 구현 내용

- [x] API 문서화를 위해 Swagger 라이브러리 springdoc-openapi 의존성 추가
- [x] Logback 사용할 예정으로, 설정 파일 작성
- [x] BaseEntity를 생성하고 JPA Auditing을 적용해 **생성일자** & **수정일자**를 관리