### PR TITLE
패키지 구조 변경 및 .gitignore 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,intellij,java,gradle
 src/main/resources/application-db.yml
+
+# logs from logback
+logs/

--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/JpaAuditingConfiguration.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/JpaAuditingConfiguration.java
@@ -1,4 +1,4 @@
-package kr.ac.sejong.ds.palette.config;
+package kr.ac.sejong.ds.palette.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/SwaggerConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package kr.ac.sejong.ds.palette.config;
+package kr.ac.sejong.ds.palette.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;

--- a/src/main/java/kr/ac/sejong/ds/palette/common/entity/BaseEntity.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package kr.ac.sejong.ds.palette.common;
+package kr.ac.sejong.ds.palette.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;


### PR DESCRIPTION
## 📄 Description

- close : #6 

> 도메인형 패키지 구조 설계에 맞게 구현하기 전 사소한 패키지 구조를 변경하고, log 파일을 추적하지 않게 하기 위해 .gitignore 수정함

## 📌 구현 내용

- [x] config 패키지를 common 패키지로 옮기기
- [x] BaseEntity를 entity 패키지 내에서 관리
- [x] .gitignore 수정을 통해 log 파일 추적 X