### PR TITLE
쿠키 관련 CORS 문제 해결을 위한 HTTPS 적용

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,7 @@ jobs:
 
     # 3. 최신 이미지 컨테이너화하여 실행시
     - name: docker run new container
-      run: docker run --rm -d -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/palette
+      run: docker run --rm -d -p 80:443 -p 443:443 ${{ secrets.DOCKERHUB_USERNAME }}/palette
 
     # 4. 기존 이미지 정리
     - name: delete old docker image

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,6 +23,8 @@ jobs:
       run: |
         echo "${{ secrets.APPLICATION_DB_YML }}" > ./src/main/resources/application-db.yml
         echo "${{ secrets.APPLICATION_JWT_YML }}" > ./src/main/resources/application-jwt.yml
+        echo "${{ secrets.APPLICATION_SSL_YML }}" > ./src/main/resources/application-ssl.yml
+        echo ${{ secrets.KEYSTORE_BASE64 }} | base64 -d > ./src/main/resources/keystore.p12
     
     # 1. Java 21 세팅
     - name: Set up JDK 21

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
         echo "${{ secrets.APPLICATION_DB_YML }}" > ./src/main/resources/application-db.yml
         echo "${{ secrets.APPLICATION_JWT_YML }}" > ./src/main/resources/application-jwt.yml
         echo "${{ secrets.APPLICATION_SSL_YML }}" > ./src/main/resources/application-ssl.yml
-        echo ${{ secrets.KEYSTORE_BASE64 }} | base64 -d > ./src/main/resources/keystore.p12
+        echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > ./src/main/resources/keystore.p12
     
     # 1. Java 21 세팅
     - name: Set up JDK 21

--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,8 @@ gradle-app.setting
 
 src/main/resources/application-db.yml
 src/main/resources/application-jwt.yml
+src/main/resources/application-ssl.yml
+src/main/resources/keystore.p12
 
 # logs from logback
 logs/

--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/CorsMvcConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/CorsMvcConfig.java
@@ -11,6 +11,6 @@ public class CorsMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry corsRegistry) {
         
         corsRegistry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000");
+                .allowedOrigins("https://localhost:5173");
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
 
                         CorsConfiguration configuration = new CorsConfiguration();
 
-                        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                        configuration.setAllowedOrigins(Collections.singletonList("https://localhost:5173"));
                         configuration.setAllowedMethods(Collections.singletonList("*"));
                         configuration.setAllowCredentials(true);
                         configuration.setAllowedHeaders(Collections.singletonList("*"));

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/CustomLogoutFilter.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/CustomLogoutFilter.java
@@ -44,9 +44,11 @@ public class CustomLogoutFilter extends GenericFilterBean {
         // get refresh token
         String refresh = null;
         Cookie[] cookies = request.getCookies();
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("refresh")) {
-                refresh = cookie.getValue();
+        if(cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                }
             }
         }
 

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/LoginFilter.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/LoginFilter.java
@@ -77,7 +77,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         // 응답 설정
         response.setHeader("access", access);
-        response.addCookie(createCookie("refresh", refresh));
+        response.setHeader("Set-Cookie", createCookie("refresh", refresh).toString());
         response.setStatus(HttpStatus.OK.value());
     }
 

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/service/JwtService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/service/JwtService.java
@@ -75,8 +75,7 @@ public class JwtService {
 
         // response
         response.setHeader("access", newAccess);
-        response.setHeader("Set-Cookie", createCookie("refresh", refresh).toString());
-
+        response.setHeader("Set-Cookie", createCookie("refresh", newRefresh).toString());
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/service/JwtService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/service/JwtService.java
@@ -75,7 +75,7 @@ public class JwtService {
 
         // response
         response.setHeader("access", newAccess);
-        response.addCookie(createCookie("refresh", newRefresh));
+        response.setHeader("Set-Cookie", createCookie("refresh", refresh).toString());
 
 
         return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/util/JWTUtil.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/util/JWTUtil.java
@@ -3,6 +3,7 @@ package kr.ac.sejong.ds.palette.jwt.util;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -47,14 +48,13 @@ public class JWTUtil {
                 .compact();
     }
 
-    public static Cookie createCookie(String key, String value) {
-
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(24*60*60);  // 생명주기 24시간
-        //cookie.setSecure(true);  // https일 경우
-        //cookie.setPath("/");  // 쿠키 적용 범위
-        cookie.setHttpOnly(true);  // 클라이언트 단에서 JS로 쿠키에 접근하지 못하도록 함 (보안)
-
-        return cookie;
+    public static ResponseCookie createCookie(String key, String value) {
+        return ResponseCookie.from(key, value)
+                .path("/")  // 쿠키 적용 범위
+                .sameSite("None")  // SameSite 정책
+                .httpOnly(true)  // 클라이언트 단에서 JS로 쿠키에 접근하지 못하도록 함 (보안)
+                .secure(true)  // https일 경우 적용 가능
+                .maxAge(REFRESH_TOKEN_EXP_MS.intValue() / 1000)  // 생명주기 24시간
+                .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,6 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+server:
+  port: 443

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
     include:
       - db
       - jwt
+      - ssl
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 📄 Description

- close : #20 

아래 오류로 인해 쿠키 정책에 관한 문제라는 것을 알았음
SameSite 정책 문제 (크롬 브라우저 Default: lax) → lax는 제한적인 경우만 허용되는 옵션이며, 이를 완화시키는 none 옵션을 사용하여 쿠키 설정해야 함. (기본적으로 Cross-Site 간 쿠키 전송은 CSRF 공격에 취약하기 때문에 이런 정책이 존재하는 것임.)
따라서 쿠키의 SameSite를 none으로 설정하여 사용하기 위해서는 secure 옵션도 true이어야 하며, HTTPS가 필수적임
따라서 이를 적용하고자 함

> This attempt to set a cookie via a Set-Cookie header was blocked because it had the "SameSite=Lax" attribute but came from a cross-site response which was not the response to a top-level navigation.

## 📌 구현 내용

- [x] HTTPS 적용
- [x] 쿠키 생성 방식 수정 (SameSite: none)