### PR TITLE
추가적인 Member 도메인 구현

### DIFF
--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
@@ -55,10 +55,7 @@ public class SecurityConfig {
                         configuration.setAllowCredentials(true);
                         configuration.setAllowedHeaders(Collections.singletonList("*"));
                         configuration.setMaxAge(3600L);
-
-                        configuration.setExposedHeaders(
-                                Arrays.asList("access", "Set-Cookie")
-                        );
+                        configuration.setExposedHeaders(Arrays.asList("access"));
 
                         return configuration;
                     }

--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/login", "/", "/join", "/reissue").permitAll()
-                        .anyRequest().authenticated());
+                        .anyRequest().permitAll());
 
         // JWTFilter 등록
         http

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionCode.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionCode.java
@@ -9,7 +9,9 @@ public enum ExceptionCode {
 
     INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
 
-    DUPLICATED_MEMBER_EMAIL(1001, "중복된 닉네임입니다.");
+    DUPLICATED_MEMBER_EMAIL(1001, "중복된 이메일입니다."),
+    NOT_FOUND_MEMBER_ID(1002, "요청한 ID에 해당하는 멤버가 존재하지 않습니다.");
+
 
 //    INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
 //

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/LoginFilter.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/LoginFilter.java
@@ -3,14 +3,11 @@ package kr.ac.sejong.ds.palette.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletInputStream;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import kr.ac.sejong.ds.palette.jwt.dto.CustomUserDetails;
-import kr.ac.sejong.ds.palette.jwt.entity.RefreshToken;
 import kr.ac.sejong.ds.palette.jwt.service.JwtService;
 import kr.ac.sejong.ds.palette.jwt.util.JWTUtil;
-import kr.ac.sejong.ds.palette.member.dto.request.MemberLoginRequest;
+import kr.ac.sejong.ds.palette.jwt.dto.MemberLoginRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -22,7 +19,6 @@ import org.springframework.util.StreamUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
 
 import static kr.ac.sejong.ds.palette.jwt.util.JWTUtil.*;
 
@@ -37,7 +33,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
 
         // 클라이언트 요청에서 email, password 추출
-        MemberLoginRequest memberLoginRequest = new MemberLoginRequest();
+        MemberLoginRequest memberLoginRequest;
 
         try {
             ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/controller/JwtController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/controller/JwtController.java
@@ -1,19 +1,16 @@
 package kr.ac.sejong.ds.palette.jwt.controller;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import jakarta.servlet.http.Cookie;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.ac.sejong.ds.palette.jwt.service.JwtService;
 import kr.ac.sejong.ds.palette.jwt.util.JWTUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static kr.ac.sejong.ds.palette.jwt.util.JWTUtil.*;
-
+@Hidden
 @RestController
 @RequiredArgsConstructor
 public class JwtController {
@@ -23,7 +20,6 @@ public class JwtController {
 
     @PostMapping("/reissue")
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {  // 인자는 스프링 컨테이너가 자동으로 주입해주는 값
-
         return jwtService.reissue(request, response);
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/dto/MemberLoginRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/dto/MemberLoginRequest.java
@@ -1,4 +1,4 @@
-package kr.ac.sejong.ds.palette.member.dto.request;
+package kr.ac.sejong.ds.palette.jwt.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package kr.ac.sejong.ds.palette.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.ac.sejong.ds.palette.member.dto.request.MemberJoinRequest;
 import kr.ac.sejong.ds.palette.member.dto.request.MemberNicknameUpdateRequest;
@@ -10,35 +12,35 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "회원 (Member)")
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/members")
-    public void hello(){
-        System.out.println("HI");
-    }
-
+    @Operation(summary = "회원 가입")
     @PostMapping("/join")
     public ResponseEntity<MemberJoinResponse> join(@RequestBody @Valid MemberJoinRequest memberJoinRequest){
         MemberJoinResponse memberJoinResponse = memberService.join(memberJoinRequest);
         return ResponseEntity.ok().body(memberJoinResponse);
     }
 
+    @Operation(summary = "단일 회원 정보 조회")
     @GetMapping("/members/{memberId}")
     public ResponseEntity<MemberResponse> getMember(@PathVariable(name = "memberId") Long memberId){
         MemberResponse memberResponse = memberService.getMember(memberId);
         return ResponseEntity.ok().body(memberResponse);
     }
 
+    @Operation(summary = "회원 닉네임 수정")
     @PutMapping("/members/{memberId}")
     public ResponseEntity<Void> updateMemberNickname(@PathVariable(name = "memberId") Long memberId, @RequestBody @Valid MemberNicknameUpdateRequest memberNicknameUpdateRequest){
         memberService.updateNickname(memberId, memberNicknameUpdateRequest);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/members/{memberId}")
     public ResponseEntity<Void> deleteMember(@PathVariable(name = "memberId") Long memberId){
         memberService.deleteMember(memberId);

--- a/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
@@ -38,4 +38,10 @@ public class MemberController {
         memberService.updateNickname(memberId, memberNicknameUpdateRequest);
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping("/members/{memberId}")
+    public ResponseEntity<Void> deleteMember(@PathVariable(name = "memberId") Long memberId){
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
@@ -1,13 +1,14 @@
 package kr.ac.sejong.ds.palette.member.controller;
 
+import jakarta.validation.Valid;
 import kr.ac.sejong.ds.palette.member.dto.request.MemberJoinRequest;
+import kr.ac.sejong.ds.palette.member.dto.request.MemberNicknameUpdateRequest;
 import kr.ac.sejong.ds.palette.member.dto.response.MemberJoinResponse;
+import kr.ac.sejong.ds.palette.member.dto.response.MemberResponse;
 import kr.ac.sejong.ds.palette.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,12 +16,14 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @GetMapping("/members")
+    public void hello(){
+        System.out.println("HI");
+    }
+
     @PostMapping("/join")
-    public ResponseEntity<MemberJoinResponse> join(@RequestBody MemberJoinRequest memberJoinRequest){
-
-        Long joinedId = memberService.join(memberJoinRequest);
-        MemberJoinResponse memberJoinResponse = new MemberJoinResponse(joinedId);
-
+    public ResponseEntity<MemberJoinResponse> join(@RequestBody @Valid MemberJoinRequest memberJoinRequest){
+        MemberJoinResponse memberJoinResponse = memberService.join(memberJoinRequest);
         return ResponseEntity.ok().body(memberJoinResponse);
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
@@ -32,4 +32,10 @@ public class MemberController {
         MemberResponse memberResponse = memberService.getMember(memberId);
         return ResponseEntity.ok().body(memberResponse);
     }
+
+    @PutMapping("/members/{memberId}")
+    public ResponseEntity<Void> updateMemberNickname(@PathVariable(name = "memberId") Long memberId, @RequestBody @Valid MemberNicknameUpdateRequest memberNicknameUpdateRequest){
+        memberService.updateNickname(memberId, memberNicknameUpdateRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
@@ -26,4 +26,10 @@ public class MemberController {
         MemberJoinResponse memberJoinResponse = memberService.join(memberJoinRequest);
         return ResponseEntity.ok().body(memberJoinResponse);
     }
+
+    @GetMapping("/members/{memberId}")
+    public ResponseEntity<MemberResponse> getMember(@PathVariable(name = "memberId") Long memberId){
+        MemberResponse memberResponse = memberService.getMember(memberId);
+        return ResponseEntity.ok().body(memberResponse);
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/member/dto/request/MemberJoinRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/dto/request/MemberJoinRequest.java
@@ -1,16 +1,13 @@
 package kr.ac.sejong.ds.palette.member.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import kr.ac.sejong.ds.palette.member.entity.Gender;
-import lombok.Getter;
 
-@Getter
-public class MemberJoinRequest {
+public record MemberJoinRequest(
+        @NotBlank String email,
+        @NotBlank String password,
+        @NotBlank String nickname,
+        @NotBlank Gender gender
+) {
 
-    private String email;
-
-    private String password;
-
-    private String nickname;
-
-    private Gender gender;
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/member/dto/request/MemberNicknameUpdateRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/dto/request/MemberNicknameUpdateRequest.java
@@ -1,0 +1,8 @@
+package kr.ac.sejong.ds.palette.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberNicknameUpdateRequest(
+        @NotBlank String nickname
+) {
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/member/dto/response/MemberJoinResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/dto/response/MemberJoinResponse.java
@@ -1,12 +1,12 @@
 package kr.ac.sejong.ds.palette.member.dto.response;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import kr.ac.sejong.ds.palette.member.entity.Member;
 
-@Getter
-@RequiredArgsConstructor
-public class MemberJoinResponse {
+public record MemberJoinResponse(
+        Long id
+) {
 
-    private final Long id;
+    public static MemberJoinResponse of(Member member) {
+        return new MemberJoinResponse(member.getId());
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/member/dto/response/MemberResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/dto/response/MemberResponse.java
@@ -1,0 +1,17 @@
+package kr.ac.sejong.ds.palette.member.dto.response;
+
+import kr.ac.sejong.ds.palette.member.entity.Gender;
+import kr.ac.sejong.ds.palette.member.entity.Member;
+
+public record MemberResponse(
+        Long id,
+        String email,
+        String nickname,
+        Gender gender
+        // 연인 멤버 닉네임 추가?
+) {
+
+    public static MemberResponse of(Member member) {
+        return new MemberResponse(member.getId(), member.getEmail(), member.getNickname(), member.getGender());
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import kr.ac.sejong.ds.palette.common.entity.BaseEntity;
 import kr.ac.sejong.ds.palette.couple.entity.Couple;
+import kr.ac.sejong.ds.palette.member.dto.request.MemberNicknameUpdateRequest;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,5 +41,9 @@ public class Member extends BaseEntity {
         this.password = password;
         this.nickname = nickname;
         this.gender = gender;
+    }
+
+    public void updateNickname(final MemberNicknameUpdateRequest memberNicknameUpdateRequest){
+        this.nickname = memberNicknameUpdateRequest.nickname();
     }
 }


### PR DESCRIPTION
## 📄 Description

- close : #22 

> 회원 정보 조회, 회원 정보 수정, 회원 탈퇴를 구현하였으며 Swagger 문서화 적용함

## 📌 구현 내용

- [x] 회원 정보 조회
- [x] 회원 정보 수정 (닉네임)
- [x] 회원 탈퇴 구현
- [x] DTO 생성 (record 클래스 활용)
- [x] Swagger 문서화 적용