### PR TITLE
JWT 페이로드 수정 및 AuthenticationPrincipal 활용에 따른 API 수정

### DIFF
--- a/src/main/java/kr/ac/sejong/ds/palette/couple/controller/CoupleController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/couple/controller/CoupleController.java
@@ -7,8 +7,10 @@ import kr.ac.sejong.ds.palette.couple.dto.request.CoupleConnectRequest;
 import kr.ac.sejong.ds.palette.couple.dto.response.CoupleCodeResponse;
 import kr.ac.sejong.ds.palette.couple.dto.response.IsCoupleResponse;
 import kr.ac.sejong.ds.palette.couple.service.CoupleService;
+import kr.ac.sejong.ds.palette.jwt.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,30 +19,34 @@ import org.springframework.web.bind.annotation.*;
 public class CoupleController {
     private final CoupleService coupleService;
 
-    @GetMapping("/members/{memberId}/couple-codes")
+    @GetMapping("/couple-codes")
     @Operation(summary = "커플 코드 조회 (없을 시 생성)")
-    public ResponseEntity<CoupleCodeResponse> getCoupleCode(@PathVariable(name = "memberId") Long memberId){
+    public ResponseEntity<CoupleCodeResponse> getCoupleCode(Authentication authentication){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
         CoupleCodeResponse coupleCodeResponse = coupleService.getCoupleCode(memberId);
         return ResponseEntity.ok().body(coupleCodeResponse);
     }
 
-    @GetMapping("/members/{memberId}/couples")
+    @GetMapping("/couples")
     @Operation(summary = "커플 여부 확인")
-    public ResponseEntity<IsCoupleResponse> checkCouple(@PathVariable(name = "memberId") Long memberId){
+    public ResponseEntity<IsCoupleResponse> checkCouple(Authentication authentication){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
         IsCoupleResponse isCoupleResponse = coupleService.checkCouple(memberId);
         return ResponseEntity.ok().body(isCoupleResponse);
     }
 
-    @PostMapping("/members/{memberId}/couples")
+    @PostMapping("/couples")
     @Operation(summary = "커플 연결")
-    public ResponseEntity<Void> connectCouple(@PathVariable(name = "memberId") Long memberId, @RequestBody @Valid CoupleConnectRequest coupleConnectRequest){
+    public ResponseEntity<Void> connectCouple(Authentication authentication, @RequestBody @Valid CoupleConnectRequest coupleConnectRequest){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
         coupleService.createCouple(memberId, coupleConnectRequest);
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/members/{memberId}/couples")
+    @DeleteMapping("/couples")
     @Operation(summary = "커플 연결 해제")
-    public ResponseEntity<Void> disconnectCouple(@PathVariable(name = "memberId") Long memberId){
+    public ResponseEntity<Void> disconnectCouple(Authentication authentication){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
         coupleService.deleteCouple(memberId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/JWTFilter.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/JWTFilter.java
@@ -63,11 +63,12 @@ public class JWTFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 토큰에서 email 획득
+        // 토큰에서 memberId, email 획득
+        Long memberId = jwtUtil.getMemberId(accessToken);
         String email = jwtUtil.getEmail(accessToken);
 
         // Member를 생성하여 값 설정
-        Member member = new Member(email, "tmp", "tmp", Gender.MALE);
+        Member member = new Member(memberId, email, "tmp", "tmp", Gender.MALE);
 
         // UserDetails에 회원 정보 객체 담기
         CustomUserDetails customUserDetails = new CustomUserDetails(member);

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/LoginFilter.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/LoginFilter.java
@@ -68,11 +68,13 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
 
         // 유저 정보
-        String email = authentication.getName();
+        Member member = memberRepository.findByEmail(authentication.getName()).get();
+        Long memberId = member.getId();
+        String email = member.getEmail();
 
         // 토큰 생성
-        String access = jwtUtil.createJwt("access", email, ACCESS_TOKEN_EXP_MS);  // 1시간
-        String refresh = jwtUtil.createJwt("refresh", email, REFRESH_TOKEN_EXP_MS);  // 24시간
+        String access = jwtUtil.createJwt("access", memberId, email, ACCESS_TOKEN_EXP_MS);  // 1시간
+        String refresh = jwtUtil.createJwt("refresh", memberId, email, REFRESH_TOKEN_EXP_MS);  // 24시간
 
         // Refresh 토큰 저장
         jwtService.addRefreshToken(email, refresh, REFRESH_TOKEN_EXP_MS);
@@ -86,7 +88,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         ObjectMapper objectMapper = new ObjectMapper();
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");
-        Member member = memberRepository.findByEmail(email).get();
         try {
             String result = objectMapper.writeValueAsString(MemberLoginResponse.of(member));
             response.getWriter().write(result);

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/dto/CustomUserDetails.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/dto/CustomUserDetails.java
@@ -18,6 +18,10 @@ public class CustomUserDetails implements UserDetails {
         return null;
     }
 
+    public Long getMemberId(){
+        return member.getId();
+    }
+
     @Override
     public String getPassword() {
         return member.getPassword();

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/util/JWTUtil.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/util/JWTUtil.java
@@ -37,10 +37,11 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(String category, String email, Long expiredMs) {
+    public String createJwt(String category, Long memberId, String email, Long expiredMs) {
 
         return Jwts.builder()
                 .claim("category", category)
+                .claim("memberId", memberId)
                 .claim("email", email)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))

--- a/src/main/java/kr/ac/sejong/ds/palette/jwt/util/JWTUtil.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/jwt/util/JWTUtil.java
@@ -22,6 +22,11 @@ public class JWTUtil {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
+    public Long getMemberId(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("memberId", Long.class);
+    }
+
     public String getEmail(String token) {
 
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);

--- a/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package kr.ac.sejong.ds.palette.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.ac.sejong.ds.palette.jwt.dto.CustomUserDetails;
 import kr.ac.sejong.ds.palette.member.dto.request.MemberJoinRequest;
 import kr.ac.sejong.ds.palette.member.dto.request.MemberNicknameUpdateRequest;
 import kr.ac.sejong.ds.palette.member.dto.response.MemberJoinResponse;
@@ -10,6 +11,7 @@ import kr.ac.sejong.ds.palette.member.dto.response.MemberInfoResponse;
 import kr.ac.sejong.ds.palette.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "회원 (Member)")
@@ -27,22 +29,25 @@ public class MemberController {
     }
 
     @Operation(summary = "단일 회원 정보 조회")
-    @GetMapping("/members/{memberId}")
-    public ResponseEntity<MemberInfoResponse> getMemberInfo(@PathVariable(name = "memberId") Long memberId){
+    @GetMapping("/members")
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(Authentication authentication){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
         MemberInfoResponse memberInfoResponse = memberService.getMemberInfo(memberId);
         return ResponseEntity.ok().body(memberInfoResponse);
     }
 
     @Operation(summary = "회원 닉네임 수정")
-    @PutMapping("/members/{memberId}")
-    public ResponseEntity<Void> updateMemberNickname(@PathVariable(name = "memberId") Long memberId, @RequestBody @Valid MemberNicknameUpdateRequest memberNicknameUpdateRequest){
+    @PutMapping("/members")
+    public ResponseEntity<Void> updateMemberNickname(Authentication authentication, @RequestBody @Valid MemberNicknameUpdateRequest memberNicknameUpdateRequest){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
         memberService.updateNickname(memberId, memberNicknameUpdateRequest);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "회원 탈퇴")
-    @DeleteMapping("/members/{memberId}")
-    public ResponseEntity<Void> deleteMember(@PathVariable(name = "memberId") Long memberId){
+    @DeleteMapping("/members")
+    public ResponseEntity<Void> deleteMember(Authentication authentication){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
         memberService.deleteMember(memberId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
@@ -32,6 +32,15 @@ public class Member extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private Gender gender;
 
+    // Authentication Token 생성을 위한 생성자
+    public Member(Long id, String email, String password, String nickname, Gender gender) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.gender = gender;
+    }
+
     public Member(String email, String password, String nickname, Gender gender) {
         this.email = email;
         this.password = password;


### PR DESCRIPTION
## 📄 Description

- close : #26 

> JWT 페이로드에 memberId를 추가하고, 컨트롤러에서 AuthenticationPrincipal 객체를 통해 memberId를 가져오도록 수정함. API 명세 수정됨

## 📌 구현 내용

- [x] JWT 페이로드 수정 (JWT 관련 파일 수정)
- [x] 컨트롤러에서 Authentication 활용 - API 수정
