### PR TITLE
데이트 코스 도메인 추가 및 기능 구현

### DIFF
--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionType.java
@@ -21,7 +21,10 @@ public enum ExceptionType {
     NOT_MATCHING_REVIEW(HttpStatus.BAD_REQUEST, "본인의 리뷰만 수정/삭제할 수 있습니다."),
 
     // Restaurant
-    NOT_FOUND_RESTAURANT(HttpStatus.NOT_FOUND, "해당 레스토랑은 존재하지 않습니다.");
+    NOT_FOUND_RESTAURANT(HttpStatus.NOT_FOUND, "해당 레스토랑은 존재하지 않습니다."),
+
+    // DateCourse
+    NotFoundDateCourseRestaurantException(HttpStatus.NOT_FOUND, "해당 데이트 코스 레스토랑은 존재하지 않습니다.");
 
 //    // JWT
 //    USER_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보가 없습니다."),

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/datecourse/NotFoundDateCourseRestaurantException.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/datecourse/NotFoundDateCourseRestaurantException.java
@@ -1,0 +1,11 @@
+package kr.ac.sejong.ds.palette.common.exception.datecourse;
+
+import kr.ac.sejong.ds.palette.common.exception.ApplicationException;
+import kr.ac.sejong.ds.palette.common.exception.ExceptionType;
+
+public class NotFoundDateCourseRestaurantException extends ApplicationException {
+
+    public NotFoundDateCourseRestaurantException() {
+        super(ExceptionType.NOT_FOUND_COUPLE_CODE.getHttpStatus(), ExceptionType.NOT_FOUND_COUPLE_CODE.getDetail());
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/couple/entity/Couple.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/couple/entity/Couple.java
@@ -2,10 +2,13 @@ package kr.ac.sejong.ds.palette.couple.entity;
 
 import jakarta.persistence.*;
 import kr.ac.sejong.ds.palette.common.entity.BaseEntity;
+import kr.ac.sejong.ds.palette.datecourse.entity.DateCourse;
 import kr.ac.sejong.ds.palette.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -23,6 +26,9 @@ public class Couple extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "female_id")
     private Member female;
+
+    @OneToMany(mappedBy = "couple", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DateCourse> dateCourse;
 
     public Couple(Member male, Member female) {
         this.male = male;

--- a/src/main/java/kr/ac/sejong/ds/palette/couple/entity/Couple.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/couple/entity/Couple.java
@@ -27,7 +27,7 @@ public class Couple extends BaseEntity {
     @JoinColumn(name = "female_id")
     private Member female;
 
-    @OneToMany(mappedBy = "couple", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "couple", cascade = CascadeType.REMOVE)
     private List<DateCourse> dateCourse;
 
     public Couple(Member male, Member female) {

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/controller/DateCourseController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/controller/DateCourseController.java
@@ -1,0 +1,42 @@
+package kr.ac.sejong.ds.palette.datecourse.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.ac.sejong.ds.palette.datecourse.dto.request.DateCourseRequest;
+import kr.ac.sejong.ds.palette.datecourse.dto.response.DateCourseResponse;
+import kr.ac.sejong.ds.palette.datecourse.service.DateCourseService;
+import kr.ac.sejong.ds.palette.jwt.dto.CustomUserDetails;
+import kr.ac.sejong.ds.palette.review.dto.request.ReviewCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "데이트 코스 (Date Course)")
+@RestController
+@RequiredArgsConstructor
+public class DateCourseController {
+
+    private final DateCourseService dateCourseService;
+
+    @Operation(summary = "데이트 코스 생성")
+    @PostMapping("/date-courses")
+    public ResponseEntity<Void> createDateCourse(Authentication authentication, @RequestBody DateCourseRequest dateCourseRequest) {
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
+
+        dateCourseService.createDateCourse(memberId, dateCourseRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "데이트 코스 리뷰 생성")
+    @PostMapping("/date-course-restaurant/{dateCourseRestaurantId}/reviews")
+    public ResponseEntity<Void> createDateCourseRestaurantReview(Authentication authentication, @PathVariable(name = "dateCourseRestaurantId") Long dateCourseRestaurantId, @RequestBody @Valid ReviewCreateRequest reviewCreateRequest) {
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
+
+        dateCourseService.createReviewOfDateCourse(memberId, dateCourseRestaurantId, reviewCreateRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/controller/DateCourseController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/controller/DateCourseController.java
@@ -22,6 +22,15 @@ public class DateCourseController {
 
     private final DateCourseService dateCourseService;
 
+    @Operation(summary = "데이트 코스 조회")
+    @GetMapping("/date-courses")
+    public ResponseEntity<List<DateCourseResponse>> getDateCourses(Authentication authentication){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
+
+        List<DateCourseResponse> dateCourseResponseList = dateCourseService.getDateCourseList(memberId);
+        return ResponseEntity.ok().body(dateCourseResponseList);
+    }
+
     @Operation(summary = "데이트 코스 생성")
     @PostMapping("/date-courses")
     public ResponseEntity<Void> createDateCourse(Authentication authentication, @RequestBody DateCourseRequest dateCourseRequest) {

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/dto/request/DateCourseRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/dto/request/DateCourseRequest.java
@@ -1,0 +1,8 @@
+package kr.ac.sejong.ds.palette.datecourse.dto.request;
+
+public record DateCourseRequest(
+        Long rstRestaurantId,
+        Long cafeRestaurantId,
+        Long barRestaurantId
+) {
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/dto/response/DateCourseResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/dto/response/DateCourseResponse.java
@@ -1,0 +1,19 @@
+package kr.ac.sejong.ds.palette.datecourse.dto.response;
+
+import kr.ac.sejong.ds.palette.datecourse.entity.DateCourse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DateCourseResponse(
+        Long dateCourseId,
+        LocalDateTime createdAt,
+        List<DateCourseRestaurantResponse> dateCourseRestaurantList
+) {
+    public static DateCourseResponse of(DateCourse dateCourse){
+        return new DateCourseResponse(
+                dateCourse.getId(), dateCourse.getCreatedAt(),
+                dateCourse.getDateCourseRestaurants().stream().map(DateCourseRestaurantResponse::of).toList()
+        );
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/dto/response/DateCourseRestaurantResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/dto/response/DateCourseRestaurantResponse.java
@@ -1,0 +1,21 @@
+package kr.ac.sejong.ds.palette.datecourse.dto.response;
+
+import kr.ac.sejong.ds.palette.datecourse.entity.DateCourseRestaurant;
+import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantForDateCourseResponse;
+import kr.ac.sejong.ds.palette.review.dto.response.ReviewContentResponse;
+
+public record DateCourseRestaurantResponse(
+        Long dateCourseRestaurantId,
+        boolean reviewYn,
+        RestaurantForDateCourseResponse restaurant,
+        ReviewContentResponse review
+) {
+    public static DateCourseRestaurantResponse of(DateCourseRestaurant dateCourseRestaurant){
+        return new DateCourseRestaurantResponse(
+                dateCourseRestaurant.getId(),
+                dateCourseRestaurant.isReviewYn(),
+                RestaurantForDateCourseResponse.of(dateCourseRestaurant.getRestaurant()),
+                dateCourseRestaurant.getReview() != null ? ReviewContentResponse.of(dateCourseRestaurant.getReview()) : null
+        );
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourse.java
@@ -25,7 +25,7 @@ public class DateCourse extends BaseEntity {
     @JoinColumn(name = "couple_id")
     private Couple couple;
 
-    @OneToMany(mappedBy = "dateCourse", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "dateCourse", cascade = CascadeType.ALL)
     private List<DateCourseRestaurant> dateCourseRestaurants = new ArrayList<>();
 
     public DateCourse(Couple couple) {

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourse.java
@@ -1,0 +1,28 @@
+package kr.ac.sejong.ds.palette.datecourse.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import kr.ac.sejong.ds.palette.common.entity.BaseEntity;
+import kr.ac.sejong.ds.palette.couple.entity.Couple;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DateCourse extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "date_course_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "couple_id")
+    private Couple couple;
+
+    public DateCourse(Couple couple) {
+        this.couple = couple;
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourse.java
@@ -9,6 +9,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,7 +25,16 @@ public class DateCourse extends BaseEntity {
     @JoinColumn(name = "couple_id")
     private Couple couple;
 
+    @OneToMany(mappedBy = "dateCourse", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DateCourseRestaurant> dateCourseRestaurants = new ArrayList<>();
+
     public DateCourse(Couple couple) {
         this.couple = couple;
+    }
+
+    public void setDateCourseRestaurants(DateCourseRestaurant rst, DateCourseRestaurant cafe, DateCourseRestaurant bar){
+        this.dateCourseRestaurants.add(rst);
+        this.dateCourseRestaurants.add(cafe);
+        this.dateCourseRestaurants.add(bar);
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourseRestaurant.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourseRestaurant.java
@@ -1,0 +1,38 @@
+package kr.ac.sejong.ds.palette.datecourse.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DateCourseRestaurant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "date_course_restaurant_id")
+    private Long id;
+
+    @NotNull
+    private boolean reviewYn;
+
+    private Long reviewId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "date_course_id")
+    private DateCourse dateCourse;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    public DateCourseRestaurant(DateCourse dateCourse, Restaurant restaurant){
+        this.reviewYn = false;
+        this.reviewId = null;
+        this.dateCourse = dateCourse;
+        this.restaurant = restaurant;
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourseRestaurant.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourseRestaurant.java
@@ -2,7 +2,9 @@ package kr.ac.sejong.ds.palette.datecourse.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import kr.ac.sejong.ds.palette.common.entity.BaseEntity;
 import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.review.entity.Review;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DateCourseRestaurant {
+public class DateCourseRestaurant extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "date_course_restaurant_id")
@@ -18,8 +20,6 @@ public class DateCourseRestaurant {
 
     @NotNull
     private boolean reviewYn;
-
-    private Long reviewId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "date_course_id")
@@ -29,10 +29,19 @@ public class DateCourseRestaurant {
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
     public DateCourseRestaurant(DateCourse dateCourse, Restaurant restaurant){
         this.reviewYn = false;
-        this.reviewId = null;
         this.dateCourse = dateCourse;
         this.restaurant = restaurant;
+        this.review = null;
+    }
+
+    public void reviewCreated(Review review){
+        this.reviewYn = true;
+        this.review = review;
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/repository/DateCourseRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/repository/DateCourseRepository.java
@@ -1,0 +1,21 @@
+package kr.ac.sejong.ds.palette.datecourse.repository;
+
+import kr.ac.sejong.ds.palette.couple.entity.Couple;
+import kr.ac.sejong.ds.palette.datecourse.entity.DateCourse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DateCourseRepository extends JpaRepository<DateCourse, Long> {
+
+    @Query(value = "SELECT dc " +
+            "FROM DateCourse dc " +
+            "JOIN FETCH dc.dateCourseRestaurants dcr " +
+            "JOIN FETCH dcr.restaurant rst " +
+            "LEFT JOIN FETCH dcr.review r " +
+            "WHERE dc.couple.id = :coupleId " +
+            "ORDER BY dc.createdAt DESC")
+    List<DateCourse> findAllByCoupleIdWithRestaurantAndReviewOrderByCreatedAtDesc(@Param(value = "coupleId") Long coupleId);
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/repository/DateCourseRestaurantRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/repository/DateCourseRestaurantRepository.java
@@ -1,0 +1,7 @@
+package kr.ac.sejong.ds.palette.datecourse.repository;
+
+import kr.ac.sejong.ds.palette.datecourse.entity.DateCourseRestaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DateCourseRestaurantRepository extends JpaRepository<DateCourseRestaurant, Long> {
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
@@ -37,6 +37,17 @@ public class DateCourseService {
     private final DateCourseRestaurantRepository dateCourseRestaurantRepository;
     private final ReviewRepository reviewRepository;
 
+    public List<DateCourseResponse> getDateCourseList(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        Couple couple = coupleRepository.findByMaleIdOrFemaleId(memberId, memberId)
+                .orElseThrow(NotCoupleMemberException::new);
+
+        List<DateCourse> dateCourseList = dateCourseRepository.findAllByCoupleIdWithRestaurantAndReviewOrderByCreatedAtDesc(couple.getId());
+        return dateCourseList.stream().map(DateCourseResponse::of).toList();
+    }
+
     @Transactional
     public void createDateCourse(Long memberId, DateCourseRequest dateCourseRequest) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
@@ -1,0 +1,91 @@
+package kr.ac.sejong.ds.palette.datecourse.service;
+
+import kr.ac.sejong.ds.palette.common.exception.couple.NotCoupleMemberException;
+import kr.ac.sejong.ds.palette.common.exception.datecourse.NotFoundDateCourseRestaurantException;
+import kr.ac.sejong.ds.palette.common.exception.member.NotFoundMemberException;
+import kr.ac.sejong.ds.palette.common.exception.restaurant.NotFoundRestaurantException;
+import kr.ac.sejong.ds.palette.couple.entity.Couple;
+import kr.ac.sejong.ds.palette.couple.repository.CoupleRepository;
+import kr.ac.sejong.ds.palette.datecourse.dto.request.DateCourseRequest;
+import kr.ac.sejong.ds.palette.datecourse.dto.response.DateCourseResponse;
+import kr.ac.sejong.ds.palette.datecourse.entity.DateCourse;
+import kr.ac.sejong.ds.palette.datecourse.entity.DateCourseRestaurant;
+import kr.ac.sejong.ds.palette.datecourse.repository.DateCourseRepository;
+import kr.ac.sejong.ds.palette.datecourse.repository.DateCourseRestaurantRepository;
+import kr.ac.sejong.ds.palette.member.entity.Member;
+import kr.ac.sejong.ds.palette.member.repository.MemberRepository;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantRepository;
+import kr.ac.sejong.ds.palette.review.dto.request.ReviewCreateRequest;
+import kr.ac.sejong.ds.palette.review.entity.Review;
+import kr.ac.sejong.ds.palette.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DateCourseService {
+
+    private final MemberRepository memberRepository;
+    private final CoupleRepository coupleRepository;
+    private final DateCourseRepository dateCourseRepository;
+    private final RestaurantRepository restaurantRepository;
+    private final DateCourseRestaurantRepository dateCourseRestaurantRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    public void createDateCourse(Long memberId, DateCourseRequest dateCourseRequest) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        Couple couple = coupleRepository.findByMaleIdOrFemaleId(memberId, memberId)
+                .orElseThrow(NotCoupleMemberException::new);
+
+        Restaurant rstRestaurant = restaurantRepository.findById(dateCourseRequest.rstRestaurantId())
+                .orElseThrow(NotFoundRestaurantException::new);
+        Restaurant cafeRestaurant = restaurantRepository.findById(dateCourseRequest.cafeRestaurantId())
+                .orElseThrow(NotFoundRestaurantException::new);
+        Restaurant barRestaurant = restaurantRepository.findById(dateCourseRequest.barRestaurantId())
+                .orElseThrow(NotFoundRestaurantException::new);
+
+        DateCourse dateCourse = new DateCourse(couple);
+        dateCourse.setDateCourseRestaurants(
+                new DateCourseRestaurant(dateCourse, rstRestaurant),
+                new DateCourseRestaurant(dateCourse, cafeRestaurant),
+                new DateCourseRestaurant(dateCourse, barRestaurant)
+        );
+
+        dateCourseRepository.save(dateCourse);
+    }
+
+
+    @Transactional
+    public void createReviewOfDateCourse(Long memberId, Long dateCourseRestaurantId, ReviewCreateRequest reviewCreateRequest) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        Couple couple = coupleRepository.findByMaleIdOrFemaleId(memberId, memberId)
+                .orElseThrow(NotCoupleMemberException::new);
+
+        DateCourseRestaurant dateCourseRestaurant = dateCourseRestaurantRepository.findById(dateCourseRestaurantId)
+                .orElseThrow(NotFoundDateCourseRestaurantException::new);
+
+        // 리뷰 생성
+        Review review = new Review(
+                reviewCreateRequest.content(),
+                member,
+                dateCourseRestaurant.getRestaurant()
+        );
+        reviewRepository.save(review);
+
+        // 레스토랑의 리뷰 개수 증가
+        dateCourseRestaurant.getRestaurant().increaseReviewCount();
+
+        // 데이트 코스 페이지에서 리뷰 작성 완료
+        dateCourseRestaurant.reviewCreated(review);
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
@@ -46,16 +46,16 @@ public class Member extends BaseEntity {
     @NotNull
     private boolean preferenceYn;
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
     private CoupleCode coupleCode;
 
-    @OneToOne(mappedBy = "male", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "male", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private Couple coupleAsMale;
 
-    @OneToOne(mappedBy = "female", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "female", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private Couple coupleAsFemale;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<Review> reviews = new ArrayList<>();
 
     // Authentication Token 생성을 위한 생성자

--- a/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
@@ -6,9 +6,13 @@ import kr.ac.sejong.ds.palette.common.entity.BaseEntity;
 import kr.ac.sejong.ds.palette.couple.entity.Couple;
 import kr.ac.sejong.ds.palette.couple.entity.CoupleCode;
 import kr.ac.sejong.ds.palette.member.dto.request.MemberUpdateRequest;
+import kr.ac.sejong.ds.palette.review.entity.Review;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -50,6 +54,9 @@ public class Member extends BaseEntity {
 
     @OneToOne(mappedBy = "female", cascade = CascadeType.ALL, orphanRemoval = true)
     private Couple coupleAsFemale;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
 
     // Authentication Token 생성을 위한 생성자
     public Member(Long id, String email, String password, String nickname, Gender gender, String birthOfDate, String phone) {

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantForDateCourseResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantForDateCourseResponse.java
@@ -1,0 +1,22 @@
+package kr.ac.sejong.ds.palette.restaurant.dto.response;
+
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.restaurant.entity.Type;
+
+public record RestaurantForDateCourseResponse(
+        Long id,
+        String name,
+        Type type,
+        String district,
+        String address
+) {
+    public static RestaurantForDateCourseResponse of(Restaurant restaurant){
+        return new RestaurantForDateCourseResponse(
+                restaurant.getId(),
+                restaurant.getName(),
+                restaurant.getType(),
+                restaurant.getDistrict(),
+                restaurant.getAddress()
+        );
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantOverviewResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantOverviewResponse.java
@@ -14,6 +14,7 @@ public record RestaurantOverviewResponse(
         String name,
         Type type,
         String summary,
+        String address,
         Double lat,
         Double lng,
         List<CategoryResponse> categoryResponseList,
@@ -21,7 +22,7 @@ public record RestaurantOverviewResponse(
 ) {
     public static RestaurantOverviewResponse of(Restaurant rst, Set<Category> categoryList, List<Menu> menuList) {
         return new RestaurantOverviewResponse(
-                rst.getId(), rst.getName(), rst.getType(), rst.getSummary(), rst.getLat(), rst.getLng(),
+                rst.getId(), rst.getName(), rst.getType(), rst.getSummary(), rst.getAddress(), rst.getLat(), rst.getLng(),
                 categoryList.stream().map(CategoryResponse::of).toList(),
                 menuList.stream().map(RankedMenuResponse::of).toList()
         );

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCategoryRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCategoryRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface RestaurantCategoryRepository extends JpaRepository<RestaurantCategory, Long> {
-    @Query("SELECT rc.category FROM RestaurantCategory rc WHERE rc.restaurant.id = :restaurantId")
+    @Query("SELECT rc.category " +
+            "FROM RestaurantCategory rc " +
+            "WHERE rc.restaurant.id = :restaurantId")
     List<Category> findAllCategoryByRestaurantId(@Param("restaurantId") Long restaurantId);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/review/controller/ReviewController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/review/controller/ReviewController.java
@@ -9,6 +9,7 @@ import kr.ac.sejong.ds.palette.review.dto.request.ReviewUpdateRequest;
 import kr.ac.sejong.ds.palette.review.dto.response.ReviewResponse;
 import kr.ac.sejong.ds.palette.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -24,8 +25,8 @@ public class ReviewController {
 
     @Operation(summary = "레스토랑 리뷰 조회 (회원 정보 포함)")
     @GetMapping("/restaurants/{restaurantId}/reviews")
-    public ResponseEntity<List<ReviewResponse>> getReviewsByRestaurant(@PathVariable(name = "restaurantId") Long restaurantId){
-        List<ReviewResponse> reviewResponseList = reviewService.getAllReviewByRestaurant(restaurantId);
+    public ResponseEntity<List<ReviewResponse>> getReviewsByRestaurant(@PathVariable(name = "restaurantId") Long restaurantId, Pageable pageable){
+        List<ReviewResponse> reviewResponseList = reviewService.getAllReviewByRestaurant(restaurantId, pageable);
         return ResponseEntity.ok().body(reviewResponseList);
     }
 

--- a/src/main/java/kr/ac/sejong/ds/palette/review/dto/response/ReviewContentResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/review/dto/response/ReviewContentResponse.java
@@ -1,0 +1,11 @@
+package kr.ac.sejong.ds.palette.review.dto.response;
+
+import kr.ac.sejong.ds.palette.review.entity.Review;
+
+public record ReviewContentResponse(
+        String content
+) {
+    public static ReviewContentResponse of(Review review) {
+        return new ReviewContentResponse(review.getContent());
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/review/repository/ReviewRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/review/repository/ReviewRepository.java
@@ -1,13 +1,18 @@
 package kr.ac.sejong.ds.palette.review.repository;
 
 import kr.ac.sejong.ds.palette.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    @Query("select r from Review r join fetch r.member where r.restaurant.id = :restaurantId")
-    List<Review> findAllWithMemberByRestaurantId(@Param("restaurantId") Long restaurantId);
+
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "JOIN FETCH r.member " +
+            "WHERE r.restaurant.id = :restaurantId " +
+            "ORDER BY r.createdAt DESC")
+    Page<Review> findAllWithMemberByRestaurantIdOrderByCreatedAtDesc(@Param("restaurantId") Long restaurantId, Pageable pageable);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/review/service/ReviewService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/review/service/ReviewService.java
@@ -14,6 +14,7 @@ import kr.ac.sejong.ds.palette.review.dto.response.ReviewResponse;
 import kr.ac.sejong.ds.palette.review.entity.Review;
 import kr.ac.sejong.ds.palette.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,13 +30,13 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final RestaurantRepository restaurantRepository;
 
-    public List<ReviewResponse> getAllReviewByRestaurant(Long restaurantId){
+    public List<ReviewResponse> getAllReviewByRestaurant(Long restaurantId, Pageable pageable){
         // 레스토랑 존재 여부 확인
         Restaurant restaurant = restaurantRepository.findById(restaurantId)
                 .orElseThrow(NotFoundRestaurantException::new);
 
         // 해당 레스토랑의 리뷰 + 멤버 정보를 가져옴
-        List<ReviewResponse> reviewResponseList = reviewRepository.findAllWithMemberByRestaurantId(restaurantId)
+        List<ReviewResponse> reviewResponseList = reviewRepository.findAllWithMemberByRestaurantIdOrderByCreatedAtDesc(restaurantId, pageable)
                 .stream().map(ReviewResponse::of).collect(Collectors.toList());
         return reviewResponseList;
     }


### PR DESCRIPTION
## 📄 Description

- close : #40 

> 데이트 코스가 추천됨에 따라 이를 저장하고 관리하고자 하는 요구사항을 반영함
> 리뷰 페이징을 적용하였으며 커플 해제 안되는 문제를 해결함

## 📌 구현 내용

- [x] 데이트 코스 Entity, Repository 생성
- [x] 추천된 데이트 코스 저장 구현
- [x] History 페이지에서의 데이트 코스 조회, 리뷰 작성 구현
- [x] 리뷰 페이징 적용
- [x] 커플 해제 안되는 문제 해결 (cascade 전략 수정)