### PR TITLE
데이트 코스 도메인 수정 사항 반영

### DIFF
--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/dto/response/DateCourseRestaurantResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/dto/response/DateCourseRestaurantResponse.java
@@ -6,14 +6,12 @@ import kr.ac.sejong.ds.palette.review.dto.response.ReviewContentResponse;
 
 public record DateCourseRestaurantResponse(
         Long dateCourseRestaurantId,
-        boolean reviewYn,
         RestaurantForDateCourseResponse restaurant,
         ReviewContentResponse review
 ) {
     public static DateCourseRestaurantResponse of(DateCourseRestaurant dateCourseRestaurant){
         return new DateCourseRestaurantResponse(
                 dateCourseRestaurant.getId(),
-                dateCourseRestaurant.isReviewYn(),
                 RestaurantForDateCourseResponse.of(dateCourseRestaurant.getRestaurant()),
                 dateCourseRestaurant.getReview() != null ? ReviewContentResponse.of(dateCourseRestaurant.getReview()) : null
         );

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourseRestaurant.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourseRestaurant.java
@@ -18,14 +18,11 @@ public class DateCourseRestaurant extends BaseEntity {
     @Column(name = "date_course_restaurant_id")
     private Long id;
 
-    @NotNull
-    private boolean reviewYn;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "date_course_id")
     private DateCourse dateCourse;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 
@@ -34,14 +31,12 @@ public class DateCourseRestaurant extends BaseEntity {
     private Review review;
 
     public DateCourseRestaurant(DateCourse dateCourse, Restaurant restaurant){
-        this.reviewYn = false;
         this.dateCourse = dateCourse;
         this.restaurant = restaurant;
         this.review = null;
     }
 
     public void reviewCreated(Review review){
-        this.reviewYn = true;
         this.review = review;
     }
 }


### PR DESCRIPTION
## ✨ Description

- close : #42 

> - DateCourseRestaurant과 Restaurant은 일대다 관계여야 함 (Unique 제약 조건으로 인해 오류 발생)
> - review_yn 컬럼 제거 (null 여부로 판단)

## 📌 구현 내용

- [x] DateCourseRestaurant 엔티티의 restaurant 필드 ManyToOne 설정
- [x] DateCourseRestaurant 엔티티의 review_yn 컬럼 제거