### PR TITLE
데이트코스 생성 시 '레스토랑 구분' 일부만 요청 시 발생하는 오류 해결

### DIFF
--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourse.java
@@ -32,9 +32,7 @@ public class DateCourse extends BaseEntity {
         this.couple = couple;
     }
 
-    public void setDateCourseRestaurants(DateCourseRestaurant rst, DateCourseRestaurant cafe, DateCourseRestaurant bar){
-        this.dateCourseRestaurants.add(rst);
-        this.dateCourseRestaurants.add(cafe);
-        this.dateCourseRestaurants.add(bar);
+    public void addDateCourseRestaurant(DateCourseRestaurant dateCourseRestaurant){
+        this.dateCourseRestaurants.add(dateCourseRestaurant);
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
@@ -56,19 +56,25 @@ public class DateCourseService {
         Couple couple = coupleRepository.findByMaleIdOrFemaleId(memberId, memberId)
                 .orElseThrow(NotCoupleMemberException::new);
 
-        Restaurant rstRestaurant = restaurantRepository.findById(dateCourseRequest.rstRestaurantId())
-                .orElseThrow(NotFoundRestaurantException::new);
-        Restaurant cafeRestaurant = restaurantRepository.findById(dateCourseRequest.cafeRestaurantId())
-                .orElseThrow(NotFoundRestaurantException::new);
-        Restaurant barRestaurant = restaurantRepository.findById(dateCourseRequest.barRestaurantId())
-                .orElseThrow(NotFoundRestaurantException::new);
-
+        // 데이트 코스 생성
         DateCourse dateCourse = new DateCourse(couple);
-        dateCourse.setDateCourseRestaurants(
-                new DateCourseRestaurant(dateCourse, rstRestaurant),
-                new DateCourseRestaurant(dateCourse, cafeRestaurant),
-                new DateCourseRestaurant(dateCourse, barRestaurant)
-        );
+
+        // 데이트 코스 레스토랑 생성
+        if(dateCourseRequest.rstRestaurantId() != null) {
+            Restaurant rstRestaurant = restaurantRepository.findById(dateCourseRequest.rstRestaurantId())
+                    .orElseThrow(NotFoundRestaurantException::new);
+            dateCourse.addDateCourseRestaurant(new DateCourseRestaurant(dateCourse, rstRestaurant));
+        }
+        if(dateCourseRequest.cafeRestaurantId() != null) {
+            Restaurant cafeRestaurant = restaurantRepository.findById(dateCourseRequest.cafeRestaurantId())
+                    .orElseThrow(NotFoundRestaurantException::new);
+            dateCourse.addDateCourseRestaurant(new DateCourseRestaurant(dateCourse, cafeRestaurant));
+        }
+        if(dateCourseRequest.barRestaurantId() != null) {
+            Restaurant barRestaurant = restaurantRepository.findById(dateCourseRequest.barRestaurantId())
+                    .orElseThrow(NotFoundRestaurantException::new);
+            dateCourse.addDateCourseRestaurant(new DateCourseRestaurant(dateCourse, barRestaurant));
+        }
 
         dateCourseRepository.save(dateCourse);
     }


### PR DESCRIPTION
## 📄 Description

- close : #45 

> 예를 들어 음식점, 술집만 선택 시 다음과 같은 에러 발생
> `"errorMessage":"The given id must not be null"}`
>  restaurant id : null 값 처리 로직 필요함

## 📌 구현 내용

- [x] 요청 DTO에 null값 담겨있을 시 이를 처리하는 로직 작성