### PR TITLE
'신규 유저 선호 레스토랑 선택' 및 '메인 페이지 레스토랑 조회' 구현

### DIFF
--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join", "/reissue",
+                        .requestMatchers("/login", "/", "/join/**", "/reissue",
                                 "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated());
 

--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join/**", "/reissue",
+                        .requestMatchers("/login", "/", "/join/**", "/reissue", "/restaurants",
                                 "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated());
 

--- a/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join/**", "/reissue", "/restaurants",
+                        .requestMatchers("/login", "/", "/join", "/join/restaurant-candidates", "/reissue", "/restaurants",
                                 "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated());
 

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionType.java
@@ -24,7 +24,7 @@ public enum ExceptionType {
     NOT_FOUND_RESTAURANT(HttpStatus.NOT_FOUND, "해당 레스토랑은 존재하지 않습니다."),
 
     // DateCourse
-    NotFoundDateCourseRestaurantException(HttpStatus.NOT_FOUND, "해당 데이트 코스 레스토랑은 존재하지 않습니다.");
+    NOT_FOUND_DATE_COURSE_RESTAURANT(HttpStatus.NOT_FOUND, "해당 데이트 코스 레스토랑은 존재하지 않습니다.");
 
 //    // JWT
 //    USER_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보가 없습니다."),

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionType.java
@@ -22,6 +22,7 @@ public enum ExceptionType {
 
     // Restaurant
     NOT_FOUND_RESTAURANT(HttpStatus.NOT_FOUND, "해당 레스토랑은 존재하지 않습니다."),
+    FAIL_TO_SAVE_RESTAURANT_PREFERENCE(HttpStatus.INTERNAL_SERVER_ERROR, "선호 레스토랑 입력 요청에 실패하였습니다."),
 
     // DateCourse
     NOT_FOUND_DATE_COURSE_RESTAURANT(HttpStatus.NOT_FOUND, "해당 데이트 코스 레스토랑은 존재하지 않습니다.");

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/datecourse/NotFoundDateCourseRestaurantException.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/datecourse/NotFoundDateCourseRestaurantException.java
@@ -6,6 +6,6 @@ import kr.ac.sejong.ds.palette.common.exception.ExceptionType;
 public class NotFoundDateCourseRestaurantException extends ApplicationException {
 
     public NotFoundDateCourseRestaurantException() {
-        super(ExceptionType.NOT_FOUND_COUPLE_CODE.getHttpStatus(), ExceptionType.NOT_FOUND_COUPLE_CODE.getDetail());
+        super(ExceptionType.NOT_FOUND_DATE_COURSE_RESTAURANT.getHttpStatus(), ExceptionType.NOT_FOUND_DATE_COURSE_RESTAURANT.getDetail());
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/restaurant/FailToSaveRestaurantPreferenceException.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/restaurant/FailToSaveRestaurantPreferenceException.java
@@ -1,0 +1,11 @@
+package kr.ac.sejong.ds.palette.common.exception.restaurant;
+
+import kr.ac.sejong.ds.palette.common.exception.ApplicationException;
+import kr.ac.sejong.ds.palette.common.exception.ExceptionType;
+
+public class FailToSaveRestaurantPreferenceException extends ApplicationException {
+
+    public FailToSaveRestaurantPreferenceException(){
+        super(ExceptionType.FAIL_TO_SAVE_RESTAURANT_PREFERENCE.getHttpStatus(), ExceptionType.FAIL_TO_SAVE_RESTAURANT_PREFERENCE.getDetail());
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
@@ -99,8 +99,8 @@ public class DateCourseService {
         );
         reviewRepository.save(review);
 
-        // 레스토랑의 리뷰 개수 증가
-        dateCourseRestaurant.getRestaurant().increaseReviewCount();
+        // 레스토랑의 리뷰 개수 증가 -> 트리거로 처리함
+        // dateCourseRestaurant.getRestaurant().increaseReviewCount();
 
         // 데이트 코스 페이지에서 리뷰 작성 완료
         dateCourseRestaurant.reviewCreated(review);

--- a/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
@@ -85,4 +85,8 @@ public class Member extends BaseEntity {
         this.birthOfDate = memberUpdateRequest.birthOfDate();
         this.phone = memberUpdateRequest.phone();
     }
+
+    public void completedPreferenceSelection(){
+        this.preferenceYn = true;
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/menu/entity/Menu.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/menu/entity/Menu.java
@@ -33,4 +33,11 @@ public class Menu extends BaseEntity {
     public static List<Menu> getRankedMenuList(List<Menu> menuList){
         return menuList.stream().filter(menu -> menu.getRanking() != null).toList();
     }
+
+    public static Menu get1stRankMenu(List<Menu> menuList){
+        return menuList.stream()
+                .filter(menu -> menu.getRanking() == 1)
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/menu/entity/Menu.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/menu/entity/Menu.java
@@ -36,7 +36,7 @@ public class Menu extends BaseEntity {
 
     public static Menu get1stRankMenu(List<Menu> menuList){
         return menuList.stream()
-                .filter(menu -> menu.getRanking() == 1)
+                .filter(menu -> menu.getRanking() != null && menu.getRanking() == 1)
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
@@ -26,7 +26,7 @@ public class RestaurantController {
 
     // 회원가입 시 선호 레스토랑 선택을 위한 레스토랑 목록 응답
     @Operation(summary = "신규 유저 선호 레스토랑 후보 목록 조회")
-    @GetMapping("/join/restaurants")
+    @GetMapping("/join/restaurant-candidates")
     public ResponseEntity<List<RestaurantPreviewResponse>> getRestaurantCandidates(){
         List<RestaurantPreviewResponse> restaurantListForNewMember = restaurantService.getRestaurantListForNewMember();
         return ResponseEntity.ok().body(restaurantListForNewMember);

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
@@ -32,6 +32,13 @@ public class RestaurantController {
         return ResponseEntity.ok().body(restaurantListForNewMember);
     }
 
+    @Operation(summary = "신규 유저 선호 레스토랑 입력 (임베딩 생성)")
+    @PostMapping("/join/restaurants")
+    public ResponseEntity<Void> saveRestaurantPreference(Authentication authentication, @RequestBody @Valid RestaurantPreferenceRequest restaurantPreferenceRequest){
+        Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
+        restaurantService.createNewMemberEmbeddings(memberId, restaurantPreferenceRequest);
+        return ResponseEntity.ok().build();
+    }
 
     @Operation(summary = "커플 레스토랑 추천")
     @GetMapping("/recommended-restaurants")

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
@@ -2,7 +2,9 @@ package kr.ac.sejong.ds.palette.restaurant.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import kr.ac.sejong.ds.palette.jwt.dto.CustomUserDetails;
+import kr.ac.sejong.ds.palette.restaurant.dto.request.RestaurantPreferenceRequest;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.RecommendedRestaurantResponse;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantPreviewResponse;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantResponse;
@@ -10,10 +12,7 @@ import kr.ac.sejong.ds.palette.restaurant.service.RestaurantService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
@@ -26,12 +25,13 @@ public class RestaurantController {
     private final RestaurantService restaurantService;
 
     // 회원가입 시 선호 레스토랑 선택을 위한 레스토랑 목록 응답
-    @Operation(summary = "신규 유저 선호 레스토랑 선택")
+    @Operation(summary = "신규 유저 선호 레스토랑 후보 목록 조회")
     @GetMapping("/join/restaurants")
     public ResponseEntity<List<RestaurantPreviewResponse>> getRestaurantCandidates(){
         List<RestaurantPreviewResponse> restaurantListForNewMember = restaurantService.getRestaurantListForNewMember();
         return ResponseEntity.ok().body(restaurantListForNewMember);
     }
+
 
     @Operation(summary = "커플 레스토랑 추천")
     @GetMapping("/recommended-restaurants")
@@ -55,10 +55,10 @@ public class RestaurantController {
         return ResponseEntity.ok().body(restaurant);
     }
 
-//    @Operation(summary = "상위 레스토랑 조회")
-//    @GetMapping("/restaurants")
-//    public ResponseEntity<List<RestaurantPreviewResponse>> getPopularRestaurants(){
-//        List<RestaurantPreviewResponse> restaurantPreviewResponseList = restaurantService.getPopularRestaurantList();
-//        return ResponseEntity.ok().body(restaurantPreviewResponseList);
-//    }
+    @Operation(summary = "메인 페이지 레스토랑 제안")
+    @GetMapping("/restaurants")
+    public ResponseEntity<List<RestaurantPreviewResponse>> getPopularRestaurants(){
+        List<RestaurantPreviewResponse> restaurantPreviewResponseList = restaurantService.getPopularRestaurantList();
+        return ResponseEntity.ok().body(restaurantPreviewResponseList);
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.ac.sejong.ds.palette.jwt.dto.CustomUserDetails;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.RecommendedRestaurantResponse;
-import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantOverviewResponse;
+import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantPreviewResponse;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantResponse;
 import kr.ac.sejong.ds.palette.restaurant.service.RestaurantService;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +25,13 @@ public class RestaurantController {
 
     private final RestaurantService restaurantService;
 
-    // 회원가입 시 선호 레스토랑 선택을 위한 무작위 레스토랑 목록 응답
-//    @GetMapping("/join/restaurants")
+    // 회원가입 시 선호 레스토랑 선택을 위한 레스토랑 목록 응답
+    @Operation(summary = "신규 유저 선호 레스토랑 선택")
+    @GetMapping("/join/restaurants")
+    public ResponseEntity<List<RestaurantPreviewResponse>> getRestaurantCandidates(){
+        List<RestaurantPreviewResponse> restaurantListForNewMember = restaurantService.getRestaurantListForNewMember();
+        return ResponseEntity.ok().body(restaurantListForNewMember);
+    }
 
     @Operation(summary = "커플 레스토랑 추천")
     @GetMapping("/recommended-restaurants")
@@ -50,49 +55,10 @@ public class RestaurantController {
         return ResponseEntity.ok().body(restaurant);
     }
 
-    @Operation(summary = "상위 레스토랑 조회")
-    @GetMapping("/restaurants")
-    public ResponseEntity<List<RestaurantOverviewResponse>> getPopularRestaurants(){
-        List<RestaurantOverviewResponse> restaurantOverviewResponseList = restaurantService.getPopularRestaurantList();
-        return ResponseEntity.ok().body(restaurantOverviewResponseList);
-    }
-//
-//
-//
-//    @Operation(summary = "모든 레스토랑 / 자치구별 레스토랑 조회")
-//    @GetMapping("/api/restaurants")
-//    public List<RestaurantResponseDto> getAllRestaurant(@Parameter(description = "자치구 (기본값: All)") @RequestParam(name = "borough", defaultValue = "All") String borough) {
-//        List<RestaurantResponseDto> restaurantResponseDto;
-//        if(borough.equals("All")){
-//            restaurantResponseDto = restaurantService.findRestaurants()
-//                    .stream().map(RestaurantResponseDto::new).collect(Collectors.toList());
-//        } else{
-//            restaurantResponseDto = restaurantService.findRestaurantsByBorough(borough)
-//                    .stream().map(RestaurantResponseDto::new).collect(Collectors.toList());
-//        }
-//        return restaurantResponseDto;
-//    }
-//
-//    @Operation(summary = "사용자 맞춤 레스토랑 조회")
-//    @GetMapping("/api/users/{userId}/recommended-restaurants")
-//    public List<RestaurantResponseDto> getRecommendedRestaurant(@Parameter(description = "사용자 id") @PathVariable(name = "userId") Long userId) {
-//        final String modelUrl = "http://3.37.115.11:5000";
-//
-//        WebClient webClient = WebClient.create(modelUrl);
-//        String response = webClient.get().uri(
-//                uriBuilder -> uriBuilder.path("/predict").queryParam("user", userId).build()
-//        ).retrieve().bodyToMono(String.class).block();
-//
-//        ObjectMapper objectMapper = new ObjectMapper();
-//        try {
-//            RecommendedRestaurantDto recommendedRestaurantDto = objectMapper.readValue(response, RecommendedRestaurantDto.class);
-//            List<Long> recommendedRestaurants = recommendedRestaurantDto.getResult();
-//            List<Restaurant> restaurants = restaurantService.findRestaurantsByIds(recommendedRestaurants);
-//            List<RestaurantResponseDto> restaurantResponseDto = restaurantService.findRestaurantsByIds(recommendedRestaurants)
-//                    .stream().map(RestaurantResponseDto::new).collect(Collectors.toList());
-//            return restaurantResponseDto;
-//        } catch (JsonProcessingException e) {
-//            throw new RuntimeException(e);
-//        }
+//    @Operation(summary = "상위 레스토랑 조회")
+//    @GetMapping("/restaurants")
+//    public ResponseEntity<List<RestaurantPreviewResponse>> getPopularRestaurants(){
+//        List<RestaurantPreviewResponse> restaurantPreviewResponseList = restaurantService.getPopularRestaurantList();
+//        return ResponseEntity.ok().body(restaurantPreviewResponseList);
 //    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/request/RestaurantPreferenceRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/request/RestaurantPreferenceRequest.java
@@ -1,0 +1,10 @@
+package kr.ac.sejong.ds.palette.restaurant.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record RestaurantPreferenceRequest(
+        @NotNull List<Long> restaurantIds
+) {
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantPreviewResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantPreviewResponse.java
@@ -1,0 +1,24 @@
+package kr.ac.sejong.ds.palette.restaurant.dto.response;
+
+import kr.ac.sejong.ds.palette.menu.dto.response.RankedMenuResponse;
+import kr.ac.sejong.ds.palette.menu.entity.Menu;
+import kr.ac.sejong.ds.palette.restaurant.entity.Category;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+
+import java.util.List;
+import java.util.Set;
+
+public record RestaurantPreviewResponse(
+        Long id,
+        String name,
+        List<CategoryResponse> categoryResponseList,
+        RankedMenuResponse rankedMenuResponse
+) {
+    public static RestaurantPreviewResponse of(Restaurant rst, Set<Category> categoryList, Menu menu) {
+        return new RestaurantPreviewResponse(
+                rst.getId(), rst.getName(),
+                categoryList.stream().map(CategoryResponse::of).toList(),
+                RankedMenuResponse.of(menu)
+        );
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/model/RestaurantPreferenceModelRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/model/RestaurantPreferenceModelRequest.java
@@ -1,0 +1,11 @@
+package kr.ac.sejong.ds.palette.restaurant.dto.response.model;
+
+import java.util.List;
+
+public record RestaurantPreferenceModelRequest(
+        List<Long> restaurantids
+) {
+    public static RestaurantPreferenceModelRequest of(List<Long> restaurantIds) {
+        return new RestaurantPreferenceModelRequest(restaurantIds);
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/Restaurant.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/Restaurant.java
@@ -50,12 +50,13 @@ public class Restaurant extends BaseEntity {
     @OneToMany(mappedBy = "restaurant")
     private List<Menu> menuList = new ArrayList<>();
 
-    public void increaseReviewCount(){
-        this.reviewCount++;
-    }
-
-    public void decreaseReviewCount(){
-        if (this.reviewCount > 0)  // 리뷰가 존재할 때 실행되므로 필요 없지 않을까? (비동기 방식일 경우를 대비?)
-            this.reviewCount--;
-    }
+    // MySQL 트리거 사용으로 대체
+//    public void increaseReviewCount(){
+//        this.reviewCount++;
+//    }
+//
+//    public void decreaseReviewCount(){
+//        if (this.reviewCount > 0)  // 리뷰가 존재할 때 실행되므로 필요 없지 않을까? (비동기 방식일 경우를 대비?)
+//            this.reviewCount--;
+//    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantCandidate.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantCandidate.java
@@ -1,0 +1,17 @@
+package kr.ac.sejong.ds.palette.restaurant.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RestaurantCandidate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long restaurantId;
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantSuggestion.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantSuggestion.java
@@ -1,0 +1,20 @@
+package kr.ac.sejong.ds.palette.restaurant.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RestaurantSuggestion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long restaurantId;
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCandidateRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCandidateRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface RestaurantCandidateRepository extends JpaRepository<RestaurantCandidate, Long> {
-    @Query("SELECT rc.id FROM RestaurantCandidate rc")
-    List<Long> findAllId();
+    @Query("SELECT rc.restaurantId FROM RestaurantCandidate rc")
+    List<Long> findAllRestaurantId();
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCandidateRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCandidateRepository.java
@@ -1,0 +1,12 @@
+package kr.ac.sejong.ds.palette.restaurant.repository;
+
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantCandidate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface RestaurantCandidateRepository extends JpaRepository<RestaurantCandidate, Long> {
+    @Query("SELECT rc.id FROM RestaurantCandidate rc")
+    List<Long> findAllId();
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantRepository.java
@@ -15,5 +15,10 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
             "WHERE r.id IN :restaurantIds ORDER BY find_in_set(r.id, :restaurantStringIds)")
     List<Restaurant> findAllByIdOrderByIdsWithMenuAndCategory(@Param("restaurantIds") List<Long> restaurantIds, @Param("restaurantStringIds") String restaurantStringIds);
 
-
+    @Query(value = "SELECT r FROM Restaurant r " +
+            "LEFT JOIN FETCH r.restaurantCategoryList rc " +
+            "LEFT JOIN FETCH rc.category c " +
+            "LEFT JOIN FETCH r.menuList m " +
+            "WHERE r.id IN :restaurantIds")
+    List<Restaurant> findAllByIdInWithMenuAndCategory(@Param("restaurantIds") List<Long> restaurantIds);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantSuggestionRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantSuggestionRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface RestaurantSuggestionRepository extends JpaRepository<RestaurantSuggestion, Long> {
-    @Query("SELECT rs.id FROM RestaurantSuggestion rs")
-    List<Long> findAllId();
+    @Query("SELECT rs.restaurantId FROM RestaurantSuggestion rs")
+    List<Long> findAllRestaurantId();
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantSuggestionRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantSuggestionRepository.java
@@ -1,0 +1,13 @@
+package kr.ac.sejong.ds.palette.restaurant.repository;
+
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantCandidate;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantSuggestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface RestaurantSuggestionRepository extends JpaRepository<RestaurantSuggestion, Long> {
+    @Query("SELECT rs.id FROM RestaurantSuggestion rs")
+    List<Long> findAllId();
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/service/RestaurantService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/service/RestaurantService.java
@@ -10,14 +10,14 @@ import kr.ac.sejong.ds.palette.menu.entity.Menu;
 import kr.ac.sejong.ds.palette.menu.repository.MenuRepository;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.RecommendedRestaurantResponse;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantOverviewResponse;
+import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantPreviewResponse;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.RestaurantResponse;
 import kr.ac.sejong.ds.palette.restaurant.dto.response.model.RecommendedRestaurantModelResponse;
 import kr.ac.sejong.ds.palette.restaurant.entity.Category;
 import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantCandidate;
 import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantCategory;
-import kr.ac.sejong.ds.palette.restaurant.repository.CategoryRepository;
-import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantCategoryRepository;
-import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantRepository;
+import kr.ac.sejong.ds.palette.restaurant.repository.*;
 import kr.ac.sejong.ds.palette.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,19 +36,25 @@ public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
     private final RestaurantCategoryRepository restaurantCategoryRepository;
-    private final CategoryRepository categoryRepository;
     private final MenuRepository menuRepository;
-    private final ReviewRepository reviewRepository;
     private final CoupleRepository coupleRepository;
+    private final RestaurantCandidateRepository restaurantCandidateRepository;
+    private final RestaurantSuggestionRepository restaurantSuggestionRepository;
 
     @Value("${server-info.model.url}")
     private String modelUrl;
 
-    // 1. 이거 랜덤으로? 아니면 2. 리뷰 많은 레스토랑?
-    // 1. 랜덤 + 메뉴 사진 있는 것만 가져오게 하고 싶은데, 쿼리가 너무 복잡해져서
-    // 만약 1로 하려면 레스토랑 테이블에 대표메뉴 여부(사진 여부)를 담아둬야할 듯
-    public List<RestaurantOverviewResponse> getRestaurantListForNewMember(){
-        return null;
+    public List<RestaurantPreviewResponse> getRestaurantListForNewMember(){
+        List<Long> restaurantCandidateIdList = restaurantCandidateRepository.findAllId();
+        List<Restaurant> restaurantList = restaurantRepository.findAllByIdInWithMenuAndCategory(restaurantCandidateIdList);
+
+        return restaurantList.stream().map(
+                restaurant -> RestaurantPreviewResponse.of(
+                        restaurant,
+                        restaurant.getRestaurantCategoryList().stream().map(RestaurantCategory::getCategory).collect(Collectors.toSet()),
+                        Menu.get1stRankMenu(restaurant.getMenuList())
+                )
+        ).toList();
     }
 
     public RecommendedRestaurantResponse getRecommendedRestaurantListByMemberAndDistrict(Long memberId, String district, Map<String, Boolean> restaurantTypeMap) {
@@ -132,7 +138,7 @@ public class RestaurantService {
     }
 
     // 여기에는 단순히 리뷰 많은 레스토랑?
-    public List<RestaurantOverviewResponse> getPopularRestaurantList() {
+    public List<RestaurantPreviewResponse> getPopularRestaurantList() {
         return null;
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/service/RestaurantService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/service/RestaurantService.java
@@ -90,6 +90,8 @@ public class RestaurantService {
                     return clientResponse.bodyToMono(String.class);
                 })
                 .block();
+
+        member.completedPreferenceSelection();
     }
 
     public RecommendedRestaurantResponse getRecommendedRestaurantListByMemberAndDistrict(Long memberId, String district, Map<String, Boolean> restaurantTypeMap) {

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/service/RestaurantService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/service/RestaurantService.java
@@ -68,6 +68,7 @@ public class RestaurantService {
     }
 
     // 신규 멤버 선호 레스토랑을 통한 임베딩 생성 (feat. 모델 서버)
+    @Transactional
     public void createNewMemberEmbeddings(Long memberId, RestaurantPreferenceRequest restaurantPreferenceRequest){
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/kr/ac/sejong/ds/palette/review/service/ReviewService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/review/service/ReviewService.java
@@ -55,8 +55,8 @@ public class ReviewService {
         Review review = new Review(reviewCreateRequest.content(), member, restaurant);
         reviewRepository.save(review);
 
-        // 레스토랑의 리뷰 개수 증가
-        restaurant.increaseReviewCount();
+        // 레스토랑의 리뷰 개수 증가 -> 트리거로 처리함
+        // restaurant.increaseReviewCount();
     }
 
     @Transactional
@@ -93,8 +93,8 @@ public class ReviewService {
         // 리뷰 삭제
         reviewRepository.delete(review);
 
-        // 레스토랑의 리뷰 개수 감소
-        review.getRestaurant().decreaseReviewCount();
+        // 레스토랑의 리뷰 개수 감소 -> 트리거로 처리함
+        // review.getRestaurant().decreaseReviewCount();
     }
 
 }


### PR DESCRIPTION
## 📄 Description

- close : #44 

> '신규 유저 선호 레스토랑 선택'과 '메인 페이지 레스토랑 조회'를 구현할 예정임
> - '신규 유저 선호 레스토랑 선택'은 두 가지 API가 구현됨
>   - 회원가입 시 선호 레스토랑 선택을 위한 레스토랑 목록 응답
>   - 모델 서버에 해당 레스토랑을 전송해 유저의 임베딩을 생성함 (콜드스타트 완화 방안)

## 📌 구현 내용

- [x] 신규 유저 선호 레스토랑 후보 목록 조회
- [x] 신규 유저 선호 레스토랑 입력 (임베딩 생성)
- [x] 메인 페이지 레스토랑 조회