### PR TITLE
백오피스 관리자 페이지 및 관리자 기능 구현

### DIFF
--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/controller/AdminRestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/controller/AdminRestaurantController.java
@@ -1,0 +1,30 @@
+package kr.ac.sejong.ds.palette.admin.restaurant.controller;
+
+import jakarta.validation.Valid;
+import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.MainPageRestaurantUpdateRequest;
+import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.RestaurantCreateRequest;
+import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.RestaurantUpdateRequest;
+import kr.ac.sejong.ds.palette.admin.restaurant.service.AdminRestaurantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminRestaurantController {
+
+    private final AdminRestaurantService adminRestaurantService;
+
+    @PostMapping("/restaurants")
+    public ResponseEntity<Void> createRestaurant(@RequestBody @Valid RestaurantCreateRequest request) {
+        adminRestaurantService.createRestaurant(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/restaurants")
+    public ResponseEntity<Void> updateRestaurant(@RequestBody @Valid RestaurantUpdateRequest request) {
+        adminRestaurantService.updateRestaurant(request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/controller/AdminRestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/controller/AdminRestaurantController.java
@@ -27,4 +27,10 @@ public class AdminRestaurantController {
         adminRestaurantService.updateRestaurant(request);
         return ResponseEntity.noContent().build();
     }
+
+    @PutMapping("/main-page-restaurants")
+    public ResponseEntity<Void> updateMainPageRestaurants(@RequestBody MainPageRestaurantUpdateRequest request) {
+        adminRestaurantService.updateMainPageRestaurants(request);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/controller/AdminRestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/controller/AdminRestaurantController.java
@@ -1,5 +1,7 @@
 package kr.ac.sejong.ds.palette.admin.restaurant.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.MainPageRestaurantUpdateRequest;
 import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.RestaurantCreateRequest;
@@ -9,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "관리자 (Admin)")
 @RestController
 @RequestMapping("/admin")
 @RequiredArgsConstructor
@@ -16,18 +19,21 @@ public class AdminRestaurantController {
 
     private final AdminRestaurantService adminRestaurantService;
 
+    @Operation(summary = "레스토랑 생성")
     @PostMapping("/restaurants")
     public ResponseEntity<Void> createRestaurant(@RequestBody @Valid RestaurantCreateRequest request) {
         adminRestaurantService.createRestaurant(request);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "레스토랑 수정")
     @PutMapping("/restaurants")
     public ResponseEntity<Void> updateRestaurant(@RequestBody @Valid RestaurantUpdateRequest request) {
         adminRestaurantService.updateRestaurant(request);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "레스토랑 삭제")
     @PutMapping("/main-page-restaurants")
     public ResponseEntity<Void> updateMainPageRestaurants(@RequestBody MainPageRestaurantUpdateRequest request) {
         adminRestaurantService.updateMainPageRestaurants(request);

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/MainPageRestaurantUpdateRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/MainPageRestaurantUpdateRequest.java
@@ -1,0 +1,11 @@
+package kr.ac.sejong.ds.palette.admin.restaurant.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record MainPageRestaurantUpdateRequest(
+        @NotNull(message = "레스토랑 ID 리스트는 필수입니다.")
+        List<Long> restaurantIdList
+) {}

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/RestaurantCreateRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/RestaurantCreateRequest.java
@@ -1,0 +1,42 @@
+package kr.ac.sejong.ds.palette.admin.restaurant.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.ac.sejong.ds.palette.menu.dto.request.MenuCreateRequest;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.restaurant.entity.Type;
+import java.util.List;
+
+public record RestaurantCreateRequest(
+        @NotNull Long id,
+        @NotNull String name,
+        @NotNull Type type,
+        String summary,
+        @NotNull String district,
+        @NotNull String address,
+        @NotNull Double lat,
+        @NotNull Double lng,
+        String distFromStation,
+        String openingHours,
+        String phone,
+        @NotNull int reviewCount,
+        @NotNull List<Long> categoryIdList,
+        @NotNull @Valid List<MenuCreateRequest> menuCreateRequestList
+) {
+    public Restaurant toEntity() {
+        return new Restaurant(
+                id,
+                name,
+                type,
+                summary,
+                district,
+                address,
+                lat,
+                lng,
+                distFromStation,
+                openingHours,
+                phone,
+                reviewCount
+        );
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/RestaurantUpdateRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/RestaurantUpdateRequest.java
@@ -1,0 +1,42 @@
+package kr.ac.sejong.ds.palette.admin.restaurant.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import kr.ac.sejong.ds.palette.menu.dto.request.MenuCreateRequest;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.restaurant.entity.Type;
+import java.util.List;
+
+public record RestaurantUpdateRequest(
+        @NotNull Long id,
+        @NotNull String name,
+        @NotNull Type type,
+        String summary,
+        @NotNull String district,
+        @NotNull String address,
+        @NotNull Double lat,
+        @NotNull Double lng,
+        String distFromStation,
+        String openingHours,
+        String phone,
+        @NotNull int reviewCount,
+        @NotNull List<Long> categoryIdList,
+        @NotNull @Valid List<MenuCreateRequest> menuCreateRequestList
+) {
+    public Restaurant toEntity() {
+        return new Restaurant(
+                id,
+                name,
+                type,
+                summary,
+                district,
+                address,
+                lat,
+                lng,
+                distFromStation,
+                openingHours,
+                phone,
+                reviewCount
+        );
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/service/AdminRestaurantService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/service/AdminRestaurantService.java
@@ -1,0 +1,105 @@
+package kr.ac.sejong.ds.palette.admin.restaurant.service;
+
+import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.MainPageRestaurantUpdateRequest;
+import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.RestaurantCreateRequest;
+import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.RestaurantUpdateRequest;
+import kr.ac.sejong.ds.palette.common.exception.restaurant.DuplicateRestaurantException;
+import kr.ac.sejong.ds.palette.common.exception.restaurant.NotFoundCategoryException;
+import kr.ac.sejong.ds.palette.common.exception.restaurant.NotFoundRestaurantException;
+import kr.ac.sejong.ds.palette.menu.entity.Menu;
+import kr.ac.sejong.ds.palette.menu.repository.MenuRepository;
+import kr.ac.sejong.ds.palette.restaurant.entity.Category;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantCategory;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantSuggestion;
+import kr.ac.sejong.ds.palette.restaurant.repository.CategoryRepository;
+import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantCategoryRepository;
+import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantRepository;
+import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantSuggestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminRestaurantService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantCategoryRepository restaurantCategoryRepository;
+    private final CategoryRepository categoryRepository;
+    private final MenuRepository menuRepository;
+    private final RestaurantSuggestionRepository restaurantSuggestionRepository;
+
+    @Transactional
+    public void createRestaurant(RestaurantCreateRequest request) {
+
+        // Restaurant (id는 크롤링 서버에서 관리. 따라서 함께 전달되며, 해당 id로 레스토랑 생성)
+        if (restaurantRepository.findById(request.id()).isPresent())  // id 중복 체크
+            throw new DuplicateRestaurantException();
+
+        Restaurant restaurant = request.toEntity();
+        restaurantRepository.save(restaurant);
+
+        // RestaurantCategory
+        List<Category> categoryList = categoryRepository.findAllById(request.categoryIdList());
+
+        if (categoryList.size() != request.categoryIdList().size())  // 카테고리 존재 여부 체크
+            throw new NotFoundCategoryException();
+
+
+        List<RestaurantCategory> restaurantCategoryList = categoryList.stream()
+                .map(category -> new RestaurantCategory(restaurant, category))
+                .toList();
+        restaurantCategoryRepository.saveAll(restaurantCategoryList);
+
+        // Menu
+        List<Menu> menuList = request.menuCreateRequestList().stream()
+                .map(menuCreateRequest -> menuCreateRequest.toEntity(restaurant))
+                .toList();
+        menuRepository.saveAll(menuList);
+    }
+
+    @Transactional
+    public void updateRestaurant(RestaurantUpdateRequest request) {
+
+        // Restaurant 업데이트
+        Restaurant restaurant = restaurantRepository.findById(request.id())
+                .orElseThrow(NotFoundRestaurantException::new);
+
+        restaurant.update(
+                request.name(),
+                request.type(),
+                request.summary(),
+                request.district(),
+                request.address(),
+                request.lat(),
+                request.lng(),
+                request.distFromStation(),
+                request.openingHours(),
+                request.phone(),
+                request.reviewCount()
+        );
+
+        // RestaurantCategory 업데이트
+        List<Category> categoryList = categoryRepository.findAllById(request.categoryIdList());
+
+        if (categoryList.size() != request.categoryIdList().size())  // 카테고리 존재 여부 체크
+            throw new NotFoundCategoryException();
+
+        List<RestaurantCategory> restaurantCategoryList = categoryList.stream()
+                .map(category -> new RestaurantCategory(restaurant, category))
+                .toList();
+        restaurantCategoryRepository.deleteByRestaurantId(restaurant.getId());  // 기존 RestaurantCategory 삭제
+        restaurantCategoryRepository.saveAll(restaurantCategoryList);
+
+        // Menu 업데이트
+        List<Menu> menuList = request.menuCreateRequestList().stream()
+                .map(menuCreateRequest -> menuCreateRequest.toEntity(restaurant))
+                .toList();
+        menuRepository.deleteByRestaurantId(restaurant.getId());  // 기존 Menu 삭제
+        menuRepository.saveAll(menuList);
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/service/AdminRestaurantService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/service/AdminRestaurantService.java
@@ -102,4 +102,18 @@ public class AdminRestaurantService {
         menuRepository.deleteByRestaurantId(restaurant.getId());  // 기존 Menu 삭제
         menuRepository.saveAll(menuList);
     }
+
+    @Transactional
+    public void updateMainPageRestaurants(MainPageRestaurantUpdateRequest request) {
+
+        if (restaurantRepository.countByIdIn(request.restaurantIdList()) != request.restaurantIdList().size())  // 레스토랑 존재 여부 체크
+            throw new NotFoundRestaurantException();
+
+        List<RestaurantSuggestion> restaurantSuggestionList = request.restaurantIdList().stream()
+                .map(RestaurantSuggestion::new)
+                .toList();
+
+        restaurantSuggestionRepository.deleteAll(); // 기존 메인 페이지 레스토랑 초기화
+        restaurantSuggestionRepository.saveAll(restaurantSuggestionList);
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionType.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/ExceptionType.java
@@ -23,6 +23,10 @@ public enum ExceptionType {
     // Restaurant
     NOT_FOUND_RESTAURANT(HttpStatus.NOT_FOUND, "해당 레스토랑은 존재하지 않습니다."),
     FAIL_TO_SAVE_RESTAURANT_PREFERENCE(HttpStatus.INTERNAL_SERVER_ERROR, "선호 레스토랑 입력 요청에 실패하였습니다."),
+    DUPLICATED_RESTAURANT(HttpStatus.BAD_REQUEST, "이미 등록된 레스토랑입니다."),
+
+    // Category
+    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "해당 카테고리는 존재하지 않습니다."),
 
     // DateCourse
     NOT_FOUND_DATE_COURSE_RESTAURANT(HttpStatus.NOT_FOUND, "해당 데이트 코스 레스토랑은 존재하지 않습니다.");

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/restaurant/DuplicateRestaurantException.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/restaurant/DuplicateRestaurantException.java
@@ -1,0 +1,11 @@
+package kr.ac.sejong.ds.palette.common.exception.restaurant;
+
+import kr.ac.sejong.ds.palette.common.exception.ApplicationException;
+import kr.ac.sejong.ds.palette.common.exception.ExceptionType;
+
+public class DuplicateRestaurantException extends ApplicationException {
+
+    public DuplicateRestaurantException() {
+        super(ExceptionType.DUPLICATED_RESTAURANT.getHttpStatus(), ExceptionType.DUPLICATED_RESTAURANT.getDetail());
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/common/exception/restaurant/NotFoundCategoryException.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/common/exception/restaurant/NotFoundCategoryException.java
@@ -1,0 +1,11 @@
+package kr.ac.sejong.ds.palette.common.exception.restaurant;
+
+import kr.ac.sejong.ds.palette.common.exception.ApplicationException;
+import kr.ac.sejong.ds.palette.common.exception.ExceptionType;
+
+public class NotFoundCategoryException extends ApplicationException {
+
+    public NotFoundCategoryException() {
+        super(ExceptionType.NOT_FOUND_CATEGORY.getHttpStatus(), ExceptionType.NOT_FOUND_CATEGORY.getDetail());
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/menu/dto/request/MenuCreateRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/menu/dto/request/MenuCreateRequest.java
@@ -1,0 +1,22 @@
+package kr.ac.sejong.ds.palette.menu.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import kr.ac.sejong.ds.palette.menu.entity.Menu;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+
+public record MenuCreateRequest(
+    @NotNull String name,
+    String imageUrl,
+    Integer ranking,
+    @NotNull int price
+) {
+    public Menu toEntity(Restaurant restaurant) {
+        return new Menu(
+                name,
+                imageUrl,
+                ranking,
+                price,
+                restaurant
+        );
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/menu/entity/Menu.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/menu/entity/Menu.java
@@ -30,6 +30,14 @@ public class Menu extends BaseEntity {
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 
+    public Menu(String name, String imageUrl, Integer ranking, int price, Restaurant restaurant) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.ranking = ranking;
+        this.price = price;
+        this.restaurant = restaurant;
+    }
+
     public static List<Menu> getRankedMenuList(List<Menu> menuList){
         return menuList.stream().filter(menu -> menu.getRanking() != null).toList();
     }

--- a/src/main/java/kr/ac/sejong/ds/palette/menu/repository/MenuRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/menu/repository/MenuRepository.java
@@ -2,9 +2,18 @@ package kr.ac.sejong.ds.palette.menu.repository;
 
 import kr.ac.sejong.ds.palette.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
     List<Menu> findAllByRestaurantId(Long restaurantId);
+
+    @Modifying
+    @Query("DELETE FROM Menu m " +
+            "WHERE m.restaurant.id = :restaurantId")
+    void deleteByRestaurantId(@Param("restaurantId") Long restaurantId);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/controller/RestaurantController.java
@@ -62,10 +62,10 @@ public class RestaurantController {
         return ResponseEntity.ok().body(restaurant);
     }
 
-    @Operation(summary = "메인 페이지 레스토랑 제안")
-    @GetMapping("/restaurants")
-    public ResponseEntity<List<RestaurantPreviewResponse>> getPopularRestaurants(){
-        List<RestaurantPreviewResponse> restaurantPreviewResponseList = restaurantService.getPopularRestaurantList();
+    @Operation(summary = "메인 페이지 레스토랑 목록 조회")
+    @GetMapping("/main-page-restaurants")
+    public ResponseEntity<List<RestaurantPreviewResponse>> getMainPageRestaurants(){
+        List<RestaurantPreviewResponse> restaurantPreviewResponseList = restaurantService.getMainPageRestaurantList();
         return ResponseEntity.ok().body(restaurantPreviewResponseList);
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/Restaurant.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/Restaurant.java
@@ -50,6 +50,37 @@ public class Restaurant extends BaseEntity {
     @OneToMany(mappedBy = "restaurant")
     private List<Menu> menuList = new ArrayList<>();
 
+    public Restaurant(Long id, String name, Type type, String summary, String district, String address, Double lat, Double lng, String distFromStation, String openingHours, String phone, int reviewCount) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.summary = summary;
+        this.district = district;
+        this.address = address;
+        this.lat = lat;
+        this.lng = lng;
+        this.distFromStation = distFromStation;
+        this.openingHours = openingHours;
+        this.phone = phone;
+        this.reviewCount = reviewCount;
+    }
+
+    // 모든 정보 업데이트
+    public void update(String name, Type type, String summary, String district, String address, Double lat, Double lng, String distFromStation, String openingHours, String phone, int reviewCount) {
+        this.name = name;
+        this.type = type;
+        this.summary = summary;
+        this.district = district;
+        this.address = address;
+        this.lat = lat;
+        this.lng = lng;
+        this.distFromStation = distFromStation;
+        this.openingHours = openingHours;
+        this.phone = phone;
+        this.reviewCount = reviewCount;
+    }
+
+
     // MySQL 트리거 사용으로 대체
 //    public void increaseReviewCount(){
 //        this.reviewCount++;

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantCategory.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantCategory.java
@@ -22,4 +22,9 @@ public class RestaurantCategory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
+
+    public RestaurantCategory(Restaurant restaurant, Category category) {
+        this.restaurant = restaurant;
+        this.category = category;
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantSuggestion.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantSuggestion.java
@@ -17,4 +17,8 @@ public class RestaurantSuggestion {
     private Long id;
 
     private Long restaurantId;
+
+    public RestaurantSuggestion(Long restaurantId) {
+        this.restaurantId = restaurantId;
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCategoryRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCategoryRepository.java
@@ -3,6 +3,7 @@ package kr.ac.sejong.ds.palette.restaurant.repository;
 import kr.ac.sejong.ds.palette.restaurant.entity.Category;
 import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,4 +14,9 @@ public interface RestaurantCategoryRepository extends JpaRepository<RestaurantCa
             "FROM RestaurantCategory rc " +
             "WHERE rc.restaurant.id = :restaurantId")
     List<Category> findAllCategoryByRestaurantId(@Param("restaurantId") Long restaurantId);
+
+    @Modifying
+    @Query("DELETE FROM RestaurantCategory rc " +
+            "WHERE rc.restaurant.id = :restaurantId")
+    void deleteByRestaurantId(@Param("restaurantId") Long restaurantId);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantRepository.java
@@ -21,4 +21,9 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
             "LEFT JOIN FETCH r.menuList m " +
             "WHERE r.id IN :restaurantIds")
     List<Restaurant> findAllByIdInWithMenuAndCategory(@Param("restaurantIds") List<Long> restaurantIds);
+
+    @Query(value = "SELECT COUNT(r) " +
+            "FROM Restaurant r " +
+            "WHERE r.id IN :restaurantIds")
+    long countByIdIn(@Param("restaurantIds") List<Long> restaurantIds);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/service/RestaurantService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/service/RestaurantService.java
@@ -173,7 +173,7 @@ public class RestaurantService {
         return RestaurantResponse.of(restaurant, categoryList, menuList);
     }
 
-    public List<RestaurantPreviewResponse> getPopularRestaurantList() {
+    public List<RestaurantPreviewResponse> getMainPageRestaurantList() {
         List<Long> restaurantSuggestionIdList = restaurantSuggestionRepository.findAllRestaurantId();
         List<Restaurant> restaurantList = restaurantRepository.findAllByIdInWithMenuAndCategory(restaurantSuggestionIdList);
 


### PR DESCRIPTION
## 📄 Description

- close : #54 

> 백오피스용 레스토랑 관리 기능을 구현함.
> 관리자 계정을 통해 레스토랑 및 메뉴 정보 수정, 메인 페이지 추천 레스토랑 관리 등의 작업을 수행할 수 있음. (/admin)

## 📌 구현 내용

- [x] 레스토랑 생성 및 수정 API
- [x] 메인 페이지 레스토랑 수정 API
- [x] 백오피스 관리자 페이지 구현 (with ChatGPT)

<img width="1327" alt="Image" src="https://github.com/user-attachments/assets/7b7c64e4-8c26-4408-a64e-7516d4d8ccac" />