### PR TITLE
관리자용 크롤링 데이터 통합 배치 처리 구현 (Spring Batch, MongoDB 사용)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,7 @@ src/main/resources/application-jwt.yml
 src/main/resources/application-ssl.yml
 src/main/resources/application-admin.yml
 src/main/resources/application-rabbitmq.yml
+src/main/resources/application-mongodb.yml
 src/main/resources/keystore.p12
 
 # logs from logback

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.1'
 	runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.110.Final'
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
 
 	compileOnly 'org.projectlombok:lombok'
@@ -42,6 +44,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.batch:spring-batch-test'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/controller/AdminRestaurantController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/controller/AdminRestaurantController.java
@@ -19,6 +19,13 @@ public class AdminRestaurantController {
 
     private final AdminRestaurantService adminRestaurantService;
 
+    @Operation(summary = "크롤링 데이터 기반 레스토랑 통합 배치 작업 실행")
+    @PostMapping("/crawl/restaurants")
+    public ResponseEntity<Void> executeRestaurantIntegrationBatch(@RequestParam(name = "district") String district, @RequestParam(name = "version") Integer version) {
+        adminRestaurantService.executeRestaurantIntegrationBatch(district, version);
+        return ResponseEntity.ok().build();
+    }
+
     @Operation(summary = "레스토랑 생성")
     @PostMapping("/restaurants")
     public ResponseEntity<Void> createRestaurant(@RequestBody @Valid RestaurantCreateRequest request) {
@@ -34,6 +41,13 @@ public class AdminRestaurantController {
     }
 
     @Operation(summary = "레스토랑 삭제")
+    @DeleteMapping("/restaurants/{restaurantId}")
+    public ResponseEntity<Void> deleteRestaurant(@PathVariable(name = "restaurantId") Long restaurantId) {
+        adminRestaurantService.deleteRestaurant(restaurantId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "메인페이지 레스토랑 수정")
     @PutMapping("/main-page-restaurants")
     public ResponseEntity<Void> updateMainPageRestaurants(@RequestBody MainPageRestaurantUpdateRequest request) {
         adminRestaurantService.updateMainPageRestaurants(request);

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/RestaurantCreateRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/RestaurantCreateRequest.java
@@ -4,13 +4,13 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.ac.sejong.ds.palette.menu.dto.request.MenuCreateRequest;
 import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
-import kr.ac.sejong.ds.palette.restaurant.entity.Type;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantType;
 import java.util.List;
 
 public record RestaurantCreateRequest(
         @NotNull Long id,
         @NotNull String name,
-        @NotNull Type type,
+        @NotNull RestaurantType restaurantType,
         String summary,
         @NotNull String district,
         @NotNull String address,
@@ -27,7 +27,7 @@ public record RestaurantCreateRequest(
         return new Restaurant(
                 id,
                 name,
-                type,
+                restaurantType,
                 summary,
                 district,
                 address,

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/RestaurantUpdateRequest.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/dto/request/RestaurantUpdateRequest.java
@@ -4,13 +4,14 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.ac.sejong.ds.palette.menu.dto.request.MenuCreateRequest;
 import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
-import kr.ac.sejong.ds.palette.restaurant.entity.Type;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantType;
+
 import java.util.List;
 
 public record RestaurantUpdateRequest(
         @NotNull Long id,
         @NotNull String name,
-        @NotNull Type type,
+        @NotNull RestaurantType restaurantType,
         String summary,
         @NotNull String district,
         @NotNull String address,
@@ -27,7 +28,7 @@ public record RestaurantUpdateRequest(
         return new Restaurant(
                 id,
                 name,
-                type,
+                restaurantType,
                 summary,
                 district,
                 address,

--- a/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/service/AdminRestaurantService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/admin/restaurant/service/AdminRestaurantService.java
@@ -6,6 +6,7 @@ import kr.ac.sejong.ds.palette.admin.restaurant.dto.request.RestaurantUpdateRequ
 import kr.ac.sejong.ds.palette.common.exception.restaurant.DuplicateRestaurantException;
 import kr.ac.sejong.ds.palette.common.exception.restaurant.NotFoundCategoryException;
 import kr.ac.sejong.ds.palette.common.exception.restaurant.NotFoundRestaurantException;
+import kr.ac.sejong.ds.palette.datecourse.repository.DateCourseRestaurantRepository;
 import kr.ac.sejong.ds.palette.menu.entity.Menu;
 import kr.ac.sejong.ds.palette.menu.repository.MenuRepository;
 import kr.ac.sejong.ds.palette.restaurant.entity.Category;
@@ -16,22 +17,49 @@ import kr.ac.sejong.ds.palette.restaurant.repository.CategoryRepository;
 import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantCategoryRepository;
 import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantRepository;
 import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantSuggestionRepository;
+import kr.ac.sejong.ds.palette.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AdminRestaurantService {
 
+    private final JobLauncher jobLauncher;
+    private final JobRegistry jobRegistry;
     private final RestaurantRepository restaurantRepository;
     private final RestaurantCategoryRepository restaurantCategoryRepository;
     private final CategoryRepository categoryRepository;
     private final MenuRepository menuRepository;
     private final RestaurantSuggestionRepository restaurantSuggestionRepository;
+    private final ReviewRepository reviewRepository;
+    private final DateCourseRestaurantRepository dateCourseRestaurantRepository;
+
+    public void executeRestaurantIntegrationBatch(String district, Integer version) {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("district", district)
+                .addString("version", version.toString())
+                .toJobParameters();
+        try {
+            JobExecution jobExecution = jobLauncher.run(jobRegistry.getJob("restaurantIntegrationJob"), jobParameters);
+            if (jobExecution.getStatus().isUnsuccessful()) {
+                throw new RuntimeException();
+            }
+        } catch (Exception e) {
+            log.error("레스토랑 통합 배치 작업 실행 중 오류 발생: {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
 
     @Transactional
     public void createRestaurant(RestaurantCreateRequest request) {
@@ -71,7 +99,7 @@ public class AdminRestaurantService {
 
         restaurant.update(
                 request.name(),
-                request.type(),
+                request.restaurantType(),
                 request.summary(),
                 request.district(),
                 request.address(),
@@ -92,15 +120,28 @@ public class AdminRestaurantService {
         List<RestaurantCategory> restaurantCategoryList = categoryList.stream()
                 .map(category -> new RestaurantCategory(restaurant, category))
                 .toList();
-        restaurantCategoryRepository.deleteByRestaurantId(restaurant.getId());  // 기존 RestaurantCategory 삭제
+        restaurantCategoryRepository.deleteAllByRestaurantId(restaurant.getId());  // 기존 RestaurantCategory 삭제
         restaurantCategoryRepository.saveAll(restaurantCategoryList);
 
         // Menu 업데이트
         List<Menu> menuList = request.menuCreateRequestList().stream()
                 .map(menuCreateRequest -> menuCreateRequest.toEntity(restaurant))
                 .toList();
-        menuRepository.deleteByRestaurantId(restaurant.getId());  // 기존 Menu 삭제
+        menuRepository.deleteAllByRestaurantId(restaurant.getId());  // 기존 Menu 삭제
         menuRepository.saveAll(menuList);
+    }
+
+    @Transactional
+    public void deleteRestaurant(Long restaurantId) {
+
+        if (!restaurantRepository.existsById(restaurantId))
+            throw new NotFoundRestaurantException();
+
+        restaurantCategoryRepository.deleteAllByRestaurantId(restaurantId);  // 레스토랑 카테고리 삭제
+        menuRepository.deleteAllByRestaurantId(restaurantId);  // 메뉴 삭제
+        reviewRepository.deleteAllByRestaurantId(restaurantId);  // 리뷰 삭제
+        dateCourseRestaurantRepository.deleteAllByRestaurantId(restaurantId);  // 데이트 코스 레스토랑 삭제
+        restaurantRepository.deleteById(restaurantId);  // 레스토랑 삭제
     }
 
     @Transactional

--- a/src/main/java/kr/ac/sejong/ds/palette/batch/restaurant/document/MongoRestaurant.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/batch/restaurant/document/MongoRestaurant.java
@@ -1,0 +1,112 @@
+package kr.ac.sejong.ds.palette.batch.restaurant.document;
+
+import kr.ac.sejong.ds.palette.member.entity.Member;
+import kr.ac.sejong.ds.palette.menu.entity.Menu;
+import kr.ac.sejong.ds.palette.restaurant.entity.Category;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantCategory;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantType;
+import kr.ac.sejong.ds.palette.review.entity.Review;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.util.List;
+
+@Getter
+@Document
+public class MongoRestaurant {
+
+    @Id
+    private String id;
+    
+    @Field("restaurant_id")
+    private Long restaurantId;
+    
+    private String address;
+    private String name;
+    
+    @Field("opening_hours")
+    private String openingHours;
+    
+    private String phone;
+    private String type;
+    private Double lat;
+    private Double lng;
+    
+    @Field("review_count")
+    private int reviewCount;
+    
+    private String summary;
+    private String region;
+
+    @Field("dist_from_station")
+    private String distFromStation;
+
+    @Field("categories")
+    private List<MongoRestaurantCategory> mongoRestaurantCategoryList;
+
+    @Field("menus")
+    private List<MongoMenu> mongoMenuList;
+
+    @Field("reviews")
+    private List<MongoReview> mongoReviewList;
+
+    @Getter
+    public static class MongoRestaurantCategory {
+
+        @Field("category_id")
+        private Long categoryId;
+
+        public RestaurantCategory toRestaurantCategory(Restaurant restaurant, Category category) {
+            return new RestaurantCategory(restaurant, category);
+        }
+    }
+
+    @Getter
+    public static class MongoMenu {
+
+        private String name;
+
+        @Field("image_url")
+        private String imageUrl;
+
+        private Integer ranking;
+        private int price;
+
+        public Menu toMenu(Restaurant restaurant) {
+            return new Menu(name, imageUrl, ranking, price, restaurant);
+        }
+    }
+
+    @Getter
+    public static class MongoReview {
+
+        private String content;
+        
+        @Field("member_id")
+        private Long memberId;
+
+        public Review toReview(Restaurant restaurant, Member member) {
+            return new Review(content, member, restaurant);
+        }
+    }
+
+    public Restaurant toRestaurant() {
+        return new Restaurant(
+                restaurantId,
+                name,
+                RestaurantType.valueOf((type)), // Type 변환 필요
+                summary,
+                region,
+                address,
+                lat,
+                lng,
+                distFromStation,
+                openingHours,
+                phone,
+                reviewCount
+        );
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/batch/restaurant/job/RestaurantJobConfiguration.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/batch/restaurant/job/RestaurantJobConfiguration.java
@@ -1,0 +1,104 @@
+package kr.ac.sejong.ds.palette.batch.restaurant.job;
+
+import kr.ac.sejong.ds.palette.batch.restaurant.document.MongoRestaurant;
+import kr.ac.sejong.ds.palette.common.exception.member.NotFoundMemberException;
+import kr.ac.sejong.ds.palette.common.exception.restaurant.NotFoundCategoryException;
+import kr.ac.sejong.ds.palette.member.repository.MemberRepository;
+import kr.ac.sejong.ds.palette.menu.entity.Menu;
+import kr.ac.sejong.ds.palette.menu.repository.MenuRepository;
+import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantCategory;
+import kr.ac.sejong.ds.palette.restaurant.repository.CategoryRepository;
+import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantCategoryRepository;
+import kr.ac.sejong.ds.palette.restaurant.repository.RestaurantRepository;
+import kr.ac.sejong.ds.palette.review.entity.Review;
+import kr.ac.sejong.ds.palette.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.MongoPagingItemReader;
+import org.springframework.batch.item.data.builder.MongoPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+@Configuration
+@RequiredArgsConstructor
+public class RestaurantJobConfiguration {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+    private final RestaurantRepository restaurantRepository;
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+    private final RestaurantCategoryRepository restaurantCategoryRepository;
+    private final ReviewRepository reviewRepository;
+    private final MenuRepository menuRepository;
+    private final MongoTemplate mongoTemplate;
+
+    @Bean
+    public Job restaurantIntegrationJob() {
+        return new JobBuilder("restaurantIntegrationJob", jobRepository)
+                .start(cleanDuplicatesStep())
+//                .next(insertRestaurantStep())
+                .build();
+    }
+
+    @Bean
+    public Step cleanDuplicatesStep() {  // STEP 1
+        return new StepBuilder("cleanDuplicatesStep", jobRepository)
+                .<MongoRestaurant, Restaurant>chunk(100, platformTransactionManager)
+                .reader(mongoRstReader(null))  // district는 itemReader 빈이 Step 실행 시점에 생성되며 @Value를 통해 동적으로 주입됨
+                .processor(findDuplicatesProcessor())
+                .writer(rstRemover())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public MongoPagingItemReader<MongoRestaurant> mongoRstReader(@Value("#{jobParameters['district']}") String district) {  // STEP 1/2 - reader
+
+        return new MongoPagingItemReaderBuilder<MongoRestaurant>()
+                .name("mongoRstReader")
+                .template(mongoTemplate)
+                .targetType(MongoRestaurant.class)
+                .collection(district)  // 컬렉션을 district로 설정
+                .query(new Query().addCriteria(where("region").is(district))) // district로 필터링 (혹시나 다른 지역의 레스토랑이 섞일 경우 대비)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .pageSize(100)
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<MongoRestaurant, Restaurant> findDuplicatesProcessor() {  // STEP 1 - processor
+        return item -> restaurantRepository.findById(item.getRestaurantId()).orElse(null);  // 중복되지 않는다면 null을 반환하여 writer로 넘기지 않음
+    }
+
+
+    @Bean
+    public ItemWriter<Restaurant> rstRemover() {  // STEP 1 - writer
+        return chunk -> {
+            chunk.getItems().forEach(restaurant -> {
+                restaurantCategoryRepository.deleteAllByRestaurantId(restaurant.getId());  // 연관된 레스토랑 카테고리 삭제
+                menuRepository.deleteAllByRestaurantId(restaurant.getId());  // 연관된 메뉴 삭제
+                reviewRepository.deleteAllByRestaurantId(restaurant.getId());  // 연관된 리뷰 삭제
+                restaurantRepository.delete(restaurant);  // 중복된 레스토랑 삭제
+            });
+        };
+    }
+}

--- a/src/main/java/kr/ac/sejong/ds/palette/batch/restaurant/job/RestaurantJobConfiguration.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/batch/restaurant/job/RestaurantJobConfiguration.java
@@ -55,7 +55,7 @@ public class RestaurantJobConfiguration {
     public Job restaurantIntegrationJob() {
         return new JobBuilder("restaurantIntegrationJob", jobRepository)
                 .start(cleanDuplicatesStep())
-//                .next(insertRestaurantStep())
+                .next(insertRestaurantStep())
                 .build();
     }
 
@@ -66,6 +66,16 @@ public class RestaurantJobConfiguration {
                 .reader(mongoRstReader(null))  // district는 itemReader 빈이 Step 실행 시점에 생성되며 @Value를 통해 동적으로 주입됨
                 .processor(findDuplicatesProcessor())
                 .writer(rstRemover())
+                .build();
+    }
+
+    @Bean
+    public Step insertRestaurantStep() {  // STEP 2
+        return new StepBuilder("insertRestaurantStep", jobRepository)
+                .<MongoRestaurant, Restaurant>chunk(100, platformTransactionManager)
+                .reader(mongoRstReader(null))  // district는 itemReader 빈이 Step 실행 시점에 생성되며 @Value를 통해 동적으로 주입됨
+                .processor(mongoRstToRstProcessor())
+                .writer(retWriter())
                 .build();
     }
 
@@ -98,6 +108,41 @@ public class RestaurantJobConfiguration {
                 menuRepository.deleteAllByRestaurantId(restaurant.getId());  // 연관된 메뉴 삭제
                 reviewRepository.deleteAllByRestaurantId(restaurant.getId());  // 연관된 리뷰 삭제
                 restaurantRepository.delete(restaurant);  // 중복된 레스토랑 삭제
+            });
+        };
+    }
+
+    @Bean
+    public ItemProcessor<MongoRestaurant, Restaurant> mongoRstToRstProcessor() {  // STEP 2 - processor
+        return item -> {
+            Restaurant restaurant = item.toRestaurant();  // 레스토랑 엔티티로 변환
+
+            List<RestaurantCategory> restaurantCategoryList = item.getMongoRestaurantCategoryList().stream()  // 레스토랑 카테고리 엔티티로 변환
+                    .map(mongoCategory -> mongoCategory.toRestaurantCategory(restaurant, categoryRepository.findById(mongoCategory.getCategoryId())
+                            .orElseThrow(NotFoundCategoryException::new)))
+                    .toList();
+            List<Menu> menuList = item.getMongoMenuList().stream().map(mongoMenu -> mongoMenu.toMenu(restaurant)).toList();  // 메뉴 엔티티로 변환
+            List<Review> reviewList = item.getMongoReviewList().stream()  // 리뷰 엔티티로 변환
+                    .map(mongoReview -> mongoReview.toReview(restaurant,memberRepository.findById(mongoReview.getMemberId())
+                            .orElseThrow(NotFoundMemberException::new)))
+                    .toList();
+
+            restaurantCategoryList.stream().forEach(restaurantCategory -> restaurant.getRestaurantCategoryList().add(restaurantCategory));  // 레스토랑에 레스토랑 카테고리 추가 (추후 Writer에서 영속화)
+            menuList.stream().forEach(menu -> restaurant.getMenuList().add(menu));  // 레스토랑에 메뉴 추가
+            reviewList.stream().forEach(review -> restaurant.getReviewList().add(review));  // 레스토랑에 리뷰 추가
+
+            return restaurant;
+        };
+    }
+
+    @Bean
+    public ItemWriter<Restaurant> retWriter() {  // STEP 3 - writer
+        return chunk -> {  // Restaurant 엔티티 및 연관된 엔티티들을 영속화
+            chunk.getItems().forEach(restaurant -> {
+                restaurantRepository.save(restaurant);
+                restaurantCategoryRepository.saveAll(restaurant.getRestaurantCategoryList());
+                menuRepository.saveAll(restaurant.getMenuList());
+                reviewRepository.saveAll(restaurant.getReviewList());
             });
         };
     }

--- a/src/main/java/kr/ac/sejong/ds/palette/couple/entity/Couple.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/couple/entity/Couple.java
@@ -27,9 +27,6 @@ public class Couple extends BaseEntity {
     @JoinColumn(name = "female_id")
     private Member female;
 
-    @OneToMany(mappedBy = "couple", cascade = CascadeType.REMOVE)
-    private List<DateCourse> dateCourse;
-
     public Couple(Member male, Member female) {
         this.male = male;
         this.female = female;

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/controller/DateCourseController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/controller/DateCourseController.java
@@ -40,7 +40,7 @@ public class DateCourseController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "데이트 코스 리뷰 생성")
+    @Operation(summary = "데이트 코스 리뷰 생성", description = "추천된 데이트 코스 레스토랑에 대한 리뷰를 생성함 (추천된 레스토랑에 대해서는 한 번만 리뷰를 작성할 수 있기 때문에 별도로 필요함)")
     @PostMapping("/date-course-restaurant/{dateCourseRestaurantId}/reviews")
     public ResponseEntity<Void> createDateCourseRestaurantReview(Authentication authentication, @PathVariable(name = "dateCourseRestaurantId") Long dateCourseRestaurantId, @RequestBody @Valid ReviewCreateRequest reviewCreateRequest) {
         Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourseRestaurant.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/entity/DateCourseRestaurant.java
@@ -39,4 +39,8 @@ public class DateCourseRestaurant extends BaseEntity {
     public void reviewCreated(Review review){
         this.review = review;
     }
+
+    public void reviewToNull(){
+        this.review = null;
+    }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/repository/DateCourseRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/repository/DateCourseRepository.java
@@ -3,6 +3,7 @@ package kr.ac.sejong.ds.palette.datecourse.repository;
 import kr.ac.sejong.ds.palette.couple.entity.Couple;
 import kr.ac.sejong.ds.palette.datecourse.entity.DateCourse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +19,8 @@ public interface DateCourseRepository extends JpaRepository<DateCourse, Long> {
             "WHERE dc.couple.id = :coupleId " +
             "ORDER BY dc.createdAt DESC")
     List<DateCourse> findAllByCoupleIdWithRestaurantAndReviewOrderByCreatedAtDesc(@Param(value = "coupleId") Long coupleId);
+
+    @Modifying
+    @Query("DELETE FROM DateCourse dc WHERE dc.couple.id = :coupleId")
+    void deleteAllByCoupleId(@Param("coupleId") Long coupleId);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/repository/DateCourseRestaurantRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/repository/DateCourseRestaurantRepository.java
@@ -2,6 +2,16 @@ package kr.ac.sejong.ds.palette.datecourse.repository;
 
 import kr.ac.sejong.ds.palette.datecourse.entity.DateCourseRestaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface DateCourseRestaurantRepository extends JpaRepository<DateCourseRestaurant, Long> {
+    @Modifying
+    @Query("DELETE FROM DateCourseRestaurant dcr WHERE dcr.restaurant.id = :restaurantId")
+    void deleteAllByRestaurantId(@Param("restaurantId") Long restaurantId);
+
+    Optional<DateCourseRestaurant> findByReviewId(Long reviewId);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/datecourse/service/DateCourseService.java
@@ -100,7 +100,7 @@ public class DateCourseService {
         reviewRepository.save(review);
 
         // 레스토랑의 리뷰 개수 증가 -> 트리거로 처리함
-        // dateCourseRestaurant.getRestaurant().increaseReviewCount();
+         dateCourseRestaurant.getRestaurant().increaseReviewCount();
 
         // 데이트 코스 페이지에서 리뷰 작성 완료
         dateCourseRestaurant.reviewCreated(review);

--- a/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/controller/MemberController.java
@@ -49,6 +49,6 @@ public class MemberController {
     public ResponseEntity<Void> deleteMember(Authentication authentication){
         Long memberId = ((CustomUserDetails) authentication.getPrincipal()).getMemberId();
         memberService.deleteMember(memberId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/entity/Member.java
@@ -55,18 +55,6 @@ public class Member extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private PreferenceStatus preferenceStatus;
 
-    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    private CoupleCode coupleCode;
-
-    @OneToOne(mappedBy = "male", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    private Couple coupleAsMale;
-
-    @OneToOne(mappedBy = "female", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    private Couple coupleAsFemale;
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<Review> reviews = new ArrayList<>();
-
     public Member(String email, String password, String nickname, Gender gender, String birthOfDate, String phone, Role role) {
         this.email = email;
         this.password = password;

--- a/src/main/java/kr/ac/sejong/ds/palette/member/service/MemberService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/member/service/MemberService.java
@@ -2,6 +2,10 @@ package kr.ac.sejong.ds.palette.member.service;
 
 import kr.ac.sejong.ds.palette.common.exception.member.DuplicatedEmailException;
 import kr.ac.sejong.ds.palette.common.exception.member.NotFoundMemberException;
+import kr.ac.sejong.ds.palette.couple.entity.Couple;
+import kr.ac.sejong.ds.palette.couple.repository.CoupleCodeRepository;
+import kr.ac.sejong.ds.palette.couple.repository.CoupleRepository;
+import kr.ac.sejong.ds.palette.datecourse.repository.DateCourseRepository;
 import kr.ac.sejong.ds.palette.member.dto.request.MemberJoinRequest;
 import kr.ac.sejong.ds.palette.member.dto.request.MemberUpdateRequest;
 import kr.ac.sejong.ds.palette.member.dto.response.MemberJoinResponse;
@@ -10,6 +14,7 @@ import kr.ac.sejong.ds.palette.member.entity.Gender;
 import kr.ac.sejong.ds.palette.member.entity.Member;
 import kr.ac.sejong.ds.palette.member.entity.Role;
 import kr.ac.sejong.ds.palette.member.repository.MemberRepository;
+import kr.ac.sejong.ds.palette.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -21,6 +26,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final CoupleRepository coupleRepository;
+    private final CoupleCodeRepository coupleCodeRepository;
+    private final DateCourseRepository dateCourseRepository;
+    private final ReviewRepository reviewRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Transactional
@@ -60,8 +69,17 @@ public class MemberService {
 
     @Transactional
     public void deleteMember(Long memberId){
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(NotFoundMemberException::new);
-        memberRepository.delete(member);
+
+        if (!memberRepository.existsById(memberId))
+            throw new NotFoundMemberException();
+
+        if (coupleRepository.existsByMaleIdOrFemaleId(memberId, memberId)) {  // 커플 정보가 존재하는 경우
+            Couple couple = coupleRepository.findByMaleIdOrFemaleId(memberId, memberId).get();
+            dateCourseRepository.deleteAllByCoupleId(couple.getId());  // 커플 데이트 코스 삭제
+            coupleRepository.delete(couple);  // 커플 정보 삭제
+        }
+        coupleCodeRepository.deleteByMemberId(memberId);  // 연결 코드 삭제
+        reviewRepository.deleteAllByMemberId(memberId);  // 리뷰 삭제
+        memberRepository.deleteById(memberId);  // 멤버 삭제
     }
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/menu/entity/Menu.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/menu/entity/Menu.java
@@ -44,7 +44,7 @@ public class Menu extends BaseEntity {
 
     public static Menu get1stRankMenu(List<Menu> menuList){
         return menuList.stream()
-                .filter(menu -> menu.getRanking() != null && menu.getRanking() == 1)
+                .filter(menu -> Integer.valueOf(1).equals(menu.getRanking()))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/kr/ac/sejong/ds/palette/menu/repository/MenuRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/menu/repository/MenuRepository.java
@@ -15,5 +15,5 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
     @Modifying
     @Query("DELETE FROM Menu m " +
             "WHERE m.restaurant.id = :restaurantId")
-    void deleteByRestaurantId(@Param("restaurantId") Long restaurantId);
+    void deleteAllByRestaurantId(@Param("restaurantId") Long restaurantId);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantForDateCourseResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantForDateCourseResponse.java
@@ -1,12 +1,12 @@
 package kr.ac.sejong.ds.palette.restaurant.dto.response;
 
 import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
-import kr.ac.sejong.ds.palette.restaurant.entity.Type;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantType;
 
 public record RestaurantForDateCourseResponse(
         Long id,
         String name,
-        Type type,
+        RestaurantType restaurantType,
         String district,
         String address
 ) {
@@ -14,7 +14,7 @@ public record RestaurantForDateCourseResponse(
         return new RestaurantForDateCourseResponse(
                 restaurant.getId(),
                 restaurant.getName(),
-                restaurant.getType(),
+                restaurant.getRestaurantType(),
                 restaurant.getDistrict(),
                 restaurant.getAddress()
         );

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantOverviewResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantOverviewResponse.java
@@ -3,7 +3,7 @@ package kr.ac.sejong.ds.palette.restaurant.dto.response;
 import kr.ac.sejong.ds.palette.menu.dto.response.RankedMenuResponse;
 import kr.ac.sejong.ds.palette.menu.entity.Menu;
 import kr.ac.sejong.ds.palette.restaurant.entity.Category;
-import kr.ac.sejong.ds.palette.restaurant.entity.Type;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantType;
 import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
 
 import java.util.List;
@@ -12,7 +12,7 @@ import java.util.Set;
 public record RestaurantOverviewResponse(
         Long id,
         String name,
-        Type type,
+        RestaurantType restaurantType,
         String summary,
         String address,
         Double lat,
@@ -22,7 +22,7 @@ public record RestaurantOverviewResponse(
 ) {
     public static RestaurantOverviewResponse of(Restaurant rst, Set<Category> categoryList, List<Menu> menuList) {
         return new RestaurantOverviewResponse(
-                rst.getId(), rst.getName(), rst.getType(), rst.getSummary(), rst.getAddress(), rst.getLat(), rst.getLng(),
+                rst.getId(), rst.getName(), rst.getRestaurantType(), rst.getSummary(), rst.getAddress(), rst.getLat(), rst.getLng(),
                 categoryList.stream().map(CategoryResponse::of).toList(),
                 menuList.stream().map(RankedMenuResponse::of).toList()
         );

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantResponse.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/dto/response/RestaurantResponse.java
@@ -3,7 +3,7 @@ package kr.ac.sejong.ds.palette.restaurant.dto.response;
 import kr.ac.sejong.ds.palette.menu.dto.response.MenuResponse;
 import kr.ac.sejong.ds.palette.menu.entity.Menu;
 import kr.ac.sejong.ds.palette.restaurant.entity.Category;
-import kr.ac.sejong.ds.palette.restaurant.entity.Type;
+import kr.ac.sejong.ds.palette.restaurant.entity.RestaurantType;
 import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
 
 import java.util.List;
@@ -11,7 +11,7 @@ import java.util.List;
 public record RestaurantResponse(
         Long id,
         String name,
-        Type type,
+        RestaurantType restaurantType,
         String summary,
         String address,
         Double lat,
@@ -25,7 +25,7 @@ public record RestaurantResponse(
 ) {
     public static RestaurantResponse of(Restaurant rst, List<Category> categoryList, List<Menu> menuList) {
         return new RestaurantResponse(
-                rst.getId(), rst.getName(), rst.getType(), rst.getSummary(), rst.getAddress(), rst.getLat(), rst.getLng(), rst.getDistFromStation(), rst.getOpeningHours(), rst.getPhone(), rst.getReviewCount(),
+                rst.getId(), rst.getName(), rst.getRestaurantType(), rst.getSummary(), rst.getAddress(), rst.getLat(), rst.getLng(), rst.getDistFromStation(), rst.getOpeningHours(), rst.getPhone(), rst.getReviewCount(),
                 categoryList.stream().map(CategoryResponse::of).toList(),
                 menuList.stream().map(MenuResponse::of).toList()
         );

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/Restaurant.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/Restaurant.java
@@ -3,6 +3,7 @@ package kr.ac.sejong.ds.palette.restaurant.entity;
 import jakarta.persistence.*;
 import kr.ac.sejong.ds.palette.common.entity.BaseEntity;
 import kr.ac.sejong.ds.palette.menu.entity.Menu;
+import kr.ac.sejong.ds.palette.review.entity.Review;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,14 +18,13 @@ import java.util.Set;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Restaurant extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "restaurant_id")
     private Long id;
 
     private String name;
 
     @Enumerated(value = EnumType.STRING)
-    private Type type;
+    private RestaurantType restaurantType;
 
     private String summary;
 
@@ -50,10 +50,13 @@ public class Restaurant extends BaseEntity {
     @OneToMany(mappedBy = "restaurant")
     private List<Menu> menuList = new ArrayList<>();
 
-    public Restaurant(Long id, String name, Type type, String summary, String district, String address, Double lat, Double lng, String distFromStation, String openingHours, String phone, int reviewCount) {
+    @OneToMany(mappedBy = "restaurant")
+    private List<Review> reviewList = new ArrayList<>();
+
+    public Restaurant(Long id, String name, RestaurantType restaurantType, String summary, String district, String address, Double lat, Double lng, String distFromStation, String openingHours, String phone, int reviewCount) {
         this.id = id;
         this.name = name;
-        this.type = type;
+        this.restaurantType = restaurantType;
         this.summary = summary;
         this.district = district;
         this.address = address;
@@ -66,9 +69,9 @@ public class Restaurant extends BaseEntity {
     }
 
     // 모든 정보 업데이트
-    public void update(String name, Type type, String summary, String district, String address, Double lat, Double lng, String distFromStation, String openingHours, String phone, int reviewCount) {
+    public void update(String name, RestaurantType restaurantType, String summary, String district, String address, Double lat, Double lng, String distFromStation, String openingHours, String phone, int reviewCount) {
         this.name = name;
-        this.type = type;
+        this.restaurantType = restaurantType;
         this.summary = summary;
         this.district = district;
         this.address = address;

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantType.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/entity/RestaurantType.java
@@ -1,6 +1,6 @@
 package kr.ac.sejong.ds.palette.restaurant.entity;
 
-public enum Type {
+public enum RestaurantType {
     RST,
     CAFE,
     BAR;

--- a/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCategoryRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/restaurant/repository/RestaurantCategoryRepository.java
@@ -18,5 +18,5 @@ public interface RestaurantCategoryRepository extends JpaRepository<RestaurantCa
     @Modifying
     @Query("DELETE FROM RestaurantCategory rc " +
             "WHERE rc.restaurant.id = :restaurantId")
-    void deleteByRestaurantId(@Param("restaurantId") Long restaurantId);
+    void deleteAllByRestaurantId(@Param("restaurantId") Long restaurantId);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/review/repository/ReviewRepository.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/review/repository/ReviewRepository.java
@@ -4,6 +4,7 @@ import kr.ac.sejong.ds.palette.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,4 +26,11 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "AND r.id IN :reviewIds ORDER BY find_in_set(r.id, :reviewStringIds) LIMIT 30")
     List<Review> findTop30WithMemberByRestaurantIdOrderByIds(@Param("restaurantId") Long restaurantId, @Param("reviewIds") List<Long> reviewIds, @Param("reviewStringIds") String reviewStringIds);
 
+    @Modifying
+    @Query("DELETE FROM Review r WHERE r.restaurant.id = :restaurantId")
+    void deleteAllByRestaurantId(@Param("restaurantId") Long restaurantId);
+
+    @Modifying
+    @Query("DELETE FROM Review r WHERE r.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/kr/ac/sejong/ds/palette/review/service/ReviewService.java
+++ b/src/main/java/kr/ac/sejong/ds/palette/review/service/ReviewService.java
@@ -10,6 +10,7 @@ import kr.ac.sejong.ds.palette.common.exception.review.NotMatchingReviewExceptio
 import kr.ac.sejong.ds.palette.common.infra.messaging.dto.InteractionType;
 import kr.ac.sejong.ds.palette.common.infra.messaging.dto.MemberInteractionMessage;
 import kr.ac.sejong.ds.palette.common.infra.messaging.service.MessageSender;
+import kr.ac.sejong.ds.palette.datecourse.repository.DateCourseRestaurantRepository;
 import kr.ac.sejong.ds.palette.member.entity.Member;
 import kr.ac.sejong.ds.palette.member.repository.MemberRepository;
 import kr.ac.sejong.ds.palette.restaurant.entity.Restaurant;
@@ -41,6 +42,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final MemberRepository memberRepository;
     private final RestaurantRepository restaurantRepository;
+    private final DateCourseRestaurantRepository dateCourseRestaurantRepository;
 
     @Value("${server-info.model.url}")
     private String modelUrl;
@@ -155,6 +157,10 @@ public class ReviewService {
         // 본인의 리뷰인지 검증
         if(review.getMember().getId() != memberId)
             throw new NotMatchingReviewException();
+
+
+        dateCourseRestaurantRepository.findByReviewId(reviewId)  // 데이트 코스 레스토랑이 참조하는 리뷰를 null로 설정
+                .ifPresent(dateCourseRestaurant -> dateCourseRestaurant.reviewToNull());
 
         // 리뷰 삭제
         reviewRepository.delete(review);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,19 +4,22 @@ spring:
   profiles:
     include:
       - db
+      - mongodb
       - jwt
       - ssl
       - admin
       - rabbitmq
   jpa:
+    show-sql: false
     properties:
       hibernate:
-        format_sql: true
-
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+        format_sql: false
+        highlight_sql: true
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: false
 
 server:
   port: 443


### PR DESCRIPTION
## 📄 Description

- close : #58 

> 서비스에서 추천을 제공하는 지역(동)이 추가될 때마다 음식점은 약 1천 개, 리뷰는 약 10만 개에 달하는 대량의 데이터가 추가된다.
> 기존에는 크롤링 서버에서 일일히 테이블 구조에 맞춰 CSV 파일로 제공해주었으나, 이 또한 추가 작업이나 검증이 필요했고, 도메인 스펙이 변경될 경우에는 곤란해진다.
> 따라서 크롤링 서버에서는 데이터를 원본에 가까운 JSON 문서로 **MongoDB**에 적재하고, 백오피스에서 새로운 지역을 서비스하는 시점에 Mongo → MySQL로 통합하는 배치를 실행하도록 할 것이다.
> 배치 구현을 위해서는 **Spring Batch**를 사용할 것이다.

MongoDB에 저장되는 음식점 크롤링 데이터를 RDB(MySQL)에 통합시키는 배치 처리를 구현하였다.

해당 배치 Job은 2개의 Step으로 구성된다.

서비스를 시작할 지역을 파라미터로 제공하면,
1. 중복된 데이터(메뉴, 카테고리 등 연관관계가 있는 데이터)가 추가로 삽입되지 않도록 이미 저장되어 있는 레스토랑 및 연관된 데이터를 RDB에서 지운다.
2. MongoDB Document를 Restaurant 도메인과 대응되도록 변환한 뒤, RDB에 저장한다.


## 📌 구현 내용

- [x] Spring Batch 및 MongoDB 관련 의존성 추가 및 설정
- [x] Job 생성 및 Step 구현
  - 첫 번째 Step: Mongo Document를 읽어와, 데이터 중복 확인(restaurantId) 후 중복 데이터 제거 (새로 올리기 위함)
  - 두 번째 Step: Mongo Document를 읽어와, 필드와 참조 등을 서버 도메인 구조와 대응시켜 변환한 뒤 저장
- [x] 해당 배치를 실행하는 컨트롤러 및 서비스 추가
  - JobParameters는 `district`과 `version`으로 설정하여 각 Job을 고유하게 식별하도록 하도록 함(일관성(재실행)도 보장됨)
- [x] 배포를 위해 Amazon DocumentDB 구축

## 🌱 Etc

- Spring Batch의 ItemReader, ItemProcessor, ItemWriter 같은 Bean은 싱글톤으로 관리된다. 따라서 jobParameter는 Step 실행 시점에 동적으로 주입해야 하기 때문에, `@StepScope`로 Bean의 라이프사이클을 Step 실행 시점까지 늦추었다.
- Amazon DocumentDB는 VPC 내에 배포되어 따로 public endpoint가 없다!