### PR TITLE
RabbitMQ 메시지 유실 방지를 위한 영속성 설정 및 Retry 로직 추가

### DIFF
--- a/api/src/main/java/kr/ac/sejong/ds/PaletteApiApplication.java
+++ b/api/src/main/java/kr/ac/sejong/ds/PaletteApiApplication.java
@@ -2,7 +2,9 @@ package kr.ac.sejong.ds;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class PaletteApiApplication {
 

--- a/api/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/service/MessageListener.java
+++ b/api/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/service/MessageListener.java
@@ -11,6 +11,8 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -26,13 +28,20 @@ public class MessageListener {
     public void receiveMemberEmbeddingStatusMessage(MemberEmbeddingStatusMessage message) {
 
         log.info("RabbitMQ 유저 임베딩 생성 여부 메시지 수신 - memberId: {}, isSuccess: {}", message.memberId(), message.isSuccess());
-        Member member = memberRepository.findById(message.memberId())
-                .orElseThrow(NotFoundMemberException::new);
+
+        Optional<Member> optionalMember = memberRepository.findById(message.memberId());
+        if (optionalMember.isEmpty()) {  // 멤버를 찾을 수 없는 경우, 메시지를 버림
+            log.error("회원 ID를 찾을 수 없음 - memberId: {}", message.memberId());
+            return;
+        }
+
+        Member member = optionalMember.get();
+
         if (message.isSuccess()) {
             log.info("임베딩 생성 성공 - memberId: {}", message.memberId());
-            member.setPreferenceStatus(PreferenceStatus.COMPLETE);
+            member.setPreferenceStatus(PreferenceStatus.COMPLETE);  // 임베딩 생성 성공 시 필드값 COMPLETE로 변경
         } else {
-            log.info("임베딩 생성 실패 - memberId: {}", message.memberId());  // ML 서버에서 처리 실패 시, 선호 레스토랑 선택 여부 값을 다시 INCOMPLETE로 설정
+            log.info("임베딩 생성 실패 - memberId: {}", message.memberId());  // 임베딩 생성 실패 시 필드값 INCOMPLETE로 변경
             member.setPreferenceStatus(PreferenceStatus.INCOMPLETE);
         }
     }

--- a/api/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/service/MessageSender.java
+++ b/api/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/service/MessageSender.java
@@ -4,6 +4,7 @@ import kr.ac.sejong.ds.palette.common.infra.messaging.dto.BatchJobRequest;
 import kr.ac.sejong.ds.palette.common.infra.messaging.dto.MemberInteractionMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -35,15 +36,21 @@ public class MessageSender {
      * 2. Producer 역할 -> Direct Exchange 전략
     **/
     public void sendMemberInteractionMessage(MemberInteractionMessage message) {
-        rabbitTemplate.convertAndSend(interactionExchange, interactionRoutingKey, message);
+        CorrelationData correlationData = new CorrelationData("interaction-" + UUID.randomUUID());
+        rabbitTemplate.convertAndSend(interactionExchange, interactionRoutingKey, message, correlationData);
         log.info("RabbitMQ 유저 인터렉션 메시지 발행 성공 - interactionType: {}, memberId: {}, restaurantIds: {}",
                 message.interactionType(), message.memberId(), message.restaurantIdList());
     }
 
     public void sendBatchJobRequest(String jobName, Map<String, Object> params) {
+        CorrelationData correlationData = new CorrelationData("batch-" + UUID.randomUUID());
         BatchJobRequest message = new BatchJobRequest(jobName, UUID.randomUUID().toString(), params);
-        rabbitTemplate.convertAndSend(batchExchange, batchRoutingKey, message);
+        rabbitTemplate.convertAndSend(batchExchange, batchRoutingKey, message, correlationData);
         log.info("배치 Job 요청 메시지 발행 성공 - jobName: {}, jobId: {}, params: {}",
                 message.jobName(), message.jobId(), message.params());
+    }
+
+    public CorrelationData generateCorrelationData() {  // RabbitMQ 메시지 전송 시 고유한 CorrelationData를 생성하여 메시지 추적 가능
+        return new CorrelationData(UUID.randomUUID().toString());
     }
 }

--- a/api/src/main/java/kr/ac/sejong/ds/palette/member/scheduler/MemberScheduler.java
+++ b/api/src/main/java/kr/ac/sejong/ds/palette/member/scheduler/MemberScheduler.java
@@ -1,0 +1,36 @@
+package kr.ac.sejong.ds.palette.member.scheduler;
+
+import kr.ac.sejong.ds.palette.member.entity.Member;
+import kr.ac.sejong.ds.palette.member.entity.PreferenceStatus;
+import kr.ac.sejong.ds.palette.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberScheduler {
+
+    private final MemberRepository memberRepository;
+
+    @Scheduled(cron = "0 * * * * *")  // 매 분 0초에 실행
+    @Transactional
+    public void rescuePendingMembers() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(1);
+        int updatedCount = memberRepository.updatePreferenceStatusBefore(
+                PreferenceStatus.INCOMPLETE,
+                PreferenceStatus.PENDING,
+                threshold
+        );
+
+        if (updatedCount > 0) {
+            log.info("무한 PENDING 해결 스케줄러 - {}건 상태 변경됨 (PENDING → INCOMPLETE)", updatedCount);
+        }
+    }
+}

--- a/common/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/config/RabbitMqConfig.java
+++ b/common/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/config/RabbitMqConfig.java
@@ -1,23 +1,33 @@
-package kr.ac.sejong.ds.palette.infra.messaging.config;
+package kr.ac.sejong.ds.palette.common.infra.messaging.config;
 
+import kr.ac.sejong.ds.palette.common.infra.messaging.converter.PersistentJackson2JsonMessageConverter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.DirectExchange;
-import org.springframework.amqp.core.Queue;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 
+@Slf4j
 @RequiredArgsConstructor
 @Configuration
 public class RabbitMqConfig {
 
-//    private final RabbitMqProperties rabbitMqProperties;
+    @Value("${spring.rabbitmq.host}")
+    private String host;
+    @Value("${spring.rabbitmq.port}")
+    private int port;
+    @Value("${spring.rabbitmq.username}")
+    private String username;
+    @Value("${spring.rabbitmq.password}")
+    private String password;
 
     // Member Interaction
     @Value("${rabbitmq.exchanges.interaction}")
@@ -44,10 +54,10 @@ public class RabbitMqConfig {
     private String batchRoutingKey;
 
     /**
-     * 지정된 Exchange 이름으로 Direct Exchange Bean 을 생성
+     * 지정된 Exchange 이름으로 Direct Exchange Bean 을 생성 (default: durable)
      */
     @Bean
-    public DirectExchange embeddingExchange() {
+    public DirectExchange embeddingStatusExchange() {
         return new DirectExchange(embeddingStatusExchange);
     }
 
@@ -62,21 +72,24 @@ public class RabbitMqConfig {
     }
 
     /**
-     * 지정된 큐 이름으로 Queue Bean 을 생성
+     * 지정된 큐 이름으로 Queue Bean 을 생성 (durable)
      */
     @Bean
-    public Queue embeddingQueue() {
-        return new Queue(embeddingStatusQueue);
+    public Queue embeddingStatusQueue() {
+        return QueueBuilder.durable(embeddingStatusQueue)
+                .withArgument("x-dead-letter-exchange", "embedding-status.dlx")
+                .withArgument("x-dead-letter-routing-key", "embedding-status.dlq")
+                .build();
     }
 
     @Bean
     public Queue interactionQueue() {
-        return new Queue(interactionQueue);
+        return QueueBuilder.durable(interactionQueue).build();
     }
 
     @Bean
     public Queue batchQueue() {
-        return new Queue(batchQueue);
+        return QueueBuilder.durable(batchQueue).build();
     }
 
     /**
@@ -86,8 +99,8 @@ public class RabbitMqConfig {
     @Bean
     public Binding embeddingBinding() {
         return BindingBuilder
-                .bind(embeddingQueue())
-                .to(embeddingExchange())
+                .bind(embeddingStatusQueue())
+                .to(embeddingStatusExchange())
                 .with(embeddingStatusRoutingKey);
     }
 
@@ -108,21 +121,54 @@ public class RabbitMqConfig {
     }
 
     /**
+     * RabbitMQ 연동을 위한 ConnectionFactory 빈을 생성하여 반환
+     **/
+    @Bean
+    public CachingConnectionFactory connectionFactory() {
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+        connectionFactory.setHost(host);
+        connectionFactory.setPort(port);
+        connectionFactory.setUsername(username);
+        connectionFactory.setPassword(password);
+        connectionFactory.setPublisherReturns(true);  // publisher returns 활성화
+        connectionFactory.setPublisherConfirmType(CachingConnectionFactory.ConfirmType.CORRELATED);  // publisher confirm 활성화
+        return connectionFactory;
+    }
+
+    /**
      * RabbitTemplate을 생성하여 반환
      * ConnectionFactory 로 연결 후 실제 작업을 위한 Template
      */
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
-        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
-        return rabbitTemplate;
+        RetryableRabbitTemplate retryableRabbitTemplate = new RetryableRabbitTemplate(connectionFactory);  // RetryableRabbitTemplate 사용
+        retryableRabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
+
+        RetryTemplate retryTemplate = getRetryTemplate();  // Retry 설정을 위한 RetryTemplate 생성
+        retryableRabbitTemplate.setRetryTemplate(retryTemplate);  // RetryTemplate 적용
+
+        return retryableRabbitTemplate;
+    }
+
+    private static RetryTemplate getRetryTemplate() {
+
+        RetryTemplate retryTemplate = new RetryTemplate();  // RetryTemplate 생성
+        SimpleRetryPolicy simpleRetryPolicy = new SimpleRetryPolicy(3);  // RetryPolicy - 최대 3회 재시도
+        ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();  // BackOffPolicy - 1초 → 2초 → 4초 간격으로 재시도
+        backOffPolicy.setInitialInterval(1000);
+        backOffPolicy.setMultiplier(2);
+        backOffPolicy.setMaxInterval(4000);
+
+        retryTemplate.setRetryPolicy(simpleRetryPolicy);  // RetryPolicy 적용
+        retryTemplate.setBackOffPolicy(backOffPolicy);  // BackOffPolicy 적용
+        return retryTemplate;
     }
 
     /**
-     * Jackson 라이브러리를 사용하여 메시지를 JSON 형식으로 변환하는 MessageConverter 빈을 생성
+     * Jackson 라이브러리를 사용하여 메시지를 JSON 형식으로 변환하는 MessageConverter 빈을 생성 (persistent message)
      */
     @Bean
     public MessageConverter jackson2JsonMessageConverter() {
-        return new Jackson2JsonMessageConverter();
+        return new PersistentJackson2JsonMessageConverter();
     }
 }

--- a/common/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/config/RabbitMqConfig.java
+++ b/common/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/config/RabbitMqConfig.java
@@ -121,6 +121,27 @@ public class RabbitMqConfig {
     }
 
     /**
+     * DLQ (Dead Letter Queue) 설정
+     */
+
+    @Bean
+    public Queue embeddingStatusDLQ() {
+        return QueueBuilder.durable("embeddingStatus.dlq").build();
+    }
+
+    @Bean
+    public DirectExchange dlxExchange() {
+        return new DirectExchange("embeddingStatus.dlx");
+    }
+
+    @Bean
+    public Binding dlqBinding() {
+        return BindingBuilder.bind(embeddingStatusDLQ())
+                .to(dlxExchange())
+                .with("embeddingStatus.dlq");
+    }
+
+    /**
      * RabbitMQ 연동을 위한 ConnectionFactory 빈을 생성하여 반환
      **/
     @Bean

--- a/common/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/config/RetryableRabbitTemplate.java
+++ b/common/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/config/RetryableRabbitTemplate.java
@@ -1,0 +1,80 @@
+package kr.ac.sejong.ds.palette.common.infra.messaging.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.retry.support.RetryTemplate;
+
+import java.util.Map;
+
+/*
+ * RabbitTemplate을 상속받아 ReturnsCallback과 ConfirmCallback 시, 재시도 로직을 추가한 클래스
+ */
+
+@Slf4j
+public class RetryableRabbitTemplate extends RabbitTemplate {
+
+    private static final int MAX_RETRY_ATTEMPTS = 3;  // 최대 재시도 횟수
+
+    public RetryableRabbitTemplate(ConnectionFactory connectionFactory) {
+        super(connectionFactory);
+        super.setMandatory(true);  // 메시지가 라우팅되지 못할 경우 Return Callback 호출
+        initCallbacks();  // retry 로직이 적용된 ReturnsCallback과 ConfirmCallback 설정
+    }
+
+    private void initCallbacks() {
+
+        super.setReturnsCallback(returned -> {
+            log.error("메시지 라우팅 실패 - replyCode: {}, replyText: {}, exchange: {}, routingKey: {}",
+                    returned.getReplyCode(), returned.getReplyText(), returned.getExchange(), returned.getRoutingKey());
+            Message message = returned.getMessage();
+            MessageProperties props = message.getMessageProperties();
+            Map<String, Object> headers = props.getHeaders();
+
+            int retryCount = (int) headers.getOrDefault("x-retry-count", 0);
+
+            if (retryCount >= MAX_RETRY_ATTEMPTS) {  // 최대 재시도 횟수 초과
+                log.error("최대 재시도 횟수 초과");
+                return;
+            }
+
+            Message newMessage = MessageBuilder
+                    .withBody(message.getBody())
+                    .copyHeaders(headers)
+                    .setHeader("x-retry-count", retryCount + 1)
+                    .build();
+
+            log.warn("재시도 진행 (count: {})", retryCount + 1);
+            super.convertAndSend(returned.getExchange(), returned.getRoutingKey(), newMessage);
+        });
+
+        super.setConfirmCallback((correlationData, ack, cause) -> {  // ConfirmCallback: NACK 시 재시도
+            if (!ack && correlationData != null && correlationData.getReturned() != null) {
+                log.error("브로커 NACK - cause: {}", cause);
+
+                Message message = correlationData.getReturned().getMessage();
+                MessageProperties props = message.getMessageProperties();
+                Map<String, Object> headers = props.getHeaders();
+
+                int retryCount = (int) headers.getOrDefault("x-retry-count", 0);
+
+                if (retryCount >= MAX_RETRY_ATTEMPTS) {
+                    log.error("최대 재시도 횟수 초과");
+                    return;
+                }
+
+                Message newMessage = MessageBuilder
+                        .withBody(message.getBody())
+                        .copyHeaders(headers)
+                        .setHeader("x-retry-count", retryCount + 1)
+                        .build();
+
+                log.warn("재시도 진행 (count: {})", retryCount + 1);
+                super.convertAndSend(correlationData.getReturned().getExchange(), correlationData.getReturned().getRoutingKey(), newMessage);
+            }
+        });
+    }
+}

--- a/common/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/converter/PersistentJackson2JsonMessageConverter.java
+++ b/common/src/main/java/kr/ac/sejong/ds/palette/common/infra/messaging/converter/PersistentJackson2JsonMessageConverter.java
@@ -1,0 +1,15 @@
+package kr.ac.sejong.ds.palette.common.infra.messaging.converter;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+
+
+public class PersistentJackson2JsonMessageConverter extends Jackson2JsonMessageConverter {
+    @Override
+    protected Message createMessage(Object object, MessageProperties messageProperties) {
+        messageProperties.setDeliveryMode(MessageDeliveryMode.PERSISTENT);  // deliveryMode를 PERSISTENT로 설정 -> 메시지를 항상 디스크에 저장
+        return super.createMessage(object, messageProperties);
+    }
+}

--- a/common/src/main/java/kr/ac/sejong/ds/palette/member/repository/MemberRepository.java
+++ b/common/src/main/java/kr/ac/sejong/ds/palette/member/repository/MemberRepository.java
@@ -1,8 +1,14 @@
 package kr.ac.sejong.ds.palette.member.repository;
 
 import kr.ac.sejong.ds.palette.member.entity.Member;
+import kr.ac.sejong.ds.palette.member.entity.PreferenceStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -10,4 +16,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Member m SET m.preferenceStatus = :newStatus " +
+            "WHERE m.updatedAt < :threshold AND m.preferenceStatus = :currentStatus")
+    int updatePreferenceStatusBefore(@Param("newStatus") PreferenceStatus newStatus,
+                           @Param("currentStatus") PreferenceStatus currentStatus,
+                           @Param("threshold") LocalDateTime threshold);
 }


### PR DESCRIPTION
## 📄 Description

- close : #62 

> 추천 시스템과의 신뢰성 있는 메시지 기반 통신을 위해, 메시지 유실 방지를 위한 설정을 적용한다.
> 1. **Durable Queue**와 **Persistent Message**를 적용한다.
> 2. Publisher와 Subscriber 관점에서 각각 **Retry**( + **DLQ**) 로직을 작성한다.
> 3. RabbitMQ 공식문서에서, 1번과 더불어 메시지가 잘 도착했는지 확인하는 **Publisher Confirm**을 통해 완전한 Durability를 보장할 수 있다고 한다.

## 📌 구현 내용

**큐 / 메시지 설정**

- [x] Durable Queue 적용 → 서버가 재시작되어도 큐가 유지됨
- [x] Persistent Message를 적용 → 서버가 재시작되어도 메시지가 디스크에 유지됨

**Publisher 관점** (유저 인터렉션 발행)

- [x] 최초 전송에서 네트워크 오류 및 일시적인 오류 시 Retry 로직 적용 - `.setRetryTemplate()`
- [x] 큐 바인딩(라우팅) 실패 시 **ReturnCallback** Retry 로직 작성 - `.setReturnsCallback(returned -> { ... }`
- [x] 메시지가 큐에 도착하지 않아 `NACK`응답 시 **ConfirmCallback** Retry 로직 작성 - `.setConfirmCallback((correlationData, ack, cause) -> { ... }`

**Subscriber 관점** (임베딩 처리 결과 구독)

- [x] `spring.rabbitmq.listener.simple.retry` 설정
- 추천 시스템으로부터 실패 메시지를 수신한 경우, bad request로 간주하고 메시지를 버린다. (retry X)
- 외 다른 예외의 경우에는 Retry를 3회까지 수행한 뒤, **DLQ**에 전송한다.

메시지 유실 말고도, 추천 시스템의 응답이 크게 지연되거나 장애가 지속되는 경우에 Member - PreferenceStatus 필드 값이 영원히 PENDING으로 남아있을 수 있다. 따라서 스케줄러를 통해 1분 이상 지속된 PENDING은 다시 INCOMPLETE로 수정해준다.

- [x] 무기한 PENDING을 해결하기 위한 스케줄러 구현

## 🌱 Etc

- 기본적으로 Retry는 3회를 수행하며, Exponential Backoff를 적용하여 1s → 2s → 4s 간격으로 수행된다.
- Listener에서는 복잡한 로직 없이 메시지 처리만 시도하면 된다. Spring Retry가 자동으로 예외를 잡고 재시도 후 DLQ로 보낸다.